### PR TITLE
Harden RN web press events

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,3 +15,4 @@
 - In system tests, if a spec needs the click-clear-sendKeys input flow, add or use a shared package helper on `Browser`/`SystemTest` (for example `clearAndSendKeys(...)`) instead of open-coding that sequence in individual specs.
 - In system tests, if a spec needs to scroll an offscreen element into view, add or use a shared package helper on `Browser`/`SystemTest` (for example `scrollIntoView(...)` / `scrollTestIdIntoView(...)`) instead of project-local DOM query wrappers.
 - For per-example browser cleanup such as auth reset, prefer lifecycle support in `SystemTest.run(...)` / `useSystemTest*` (for example `onTeardown`) over putting destructive cleanup into app bootstrap callbacks like `onInitialize`.
+- If a downstream app exposes a bug rooted in `system-testing`, fix it in `system-testing` first and open the PR here before asking the app repo to carry a dependency override or downstream workaround.

--- a/spec/dummy/app/blank.tsx
+++ b/spec/dummy/app/blank.tsx
@@ -1,15 +1,35 @@
-import { ThemedText } from '@/components/themed-text';
-import { ThemedView } from '@/components/themed-view';
+import {useState} from "react"
+import {Pressable} from "react-native"
+
+import {ThemedText} from "@/components/themed-text"
+import {ThemedView} from "@/components/themed-view"
 
 export default function BlankScreen() {
+  const [pressed, setPressed] = useState(false)
 
   return (
     <ThemedView
-      style={{ flex: 1, alignItems: 'center', justifyContent: 'center', padding: 24 }}
+      style={{flex: 1, alignItems: "center", justifyContent: "center", padding: 24}}
     >
-      <ThemedText testID="blankText" type="title">
+      <ThemedText
+        testID="blankText"
+        type="title"
+      >
         System testing blank page
       </ThemedText>
+
+      <Pressable
+        onPress={() => setPressed(true)}
+        testID="blankPressButton"
+      >
+        <ThemedText testID="blankPressButtonText">
+          Press me
+        </ThemedText>
+      </Pressable>
+
+      <ThemedText testID={pressed ? "blankPressStatePressed" : "blankPressStateIdle"}>
+        {pressed ? "Pressed" : "Idle"}
+      </ThemedText>
     </ThemedView>
-  );
+  )
 }

--- a/spec/dummy/app/blank.tsx
+++ b/spec/dummy/app/blank.tsx
@@ -1,10 +1,12 @@
 import {ThemedText} from "@/components/themed-text"
 import {ThemedView} from "@/components/themed-view"
 
+const styles = {}
+
 export default function BlankScreen() {
   return (
     <ThemedView
-      style={{flex: 1, alignItems: "center", justifyContent: "center", padding: 24}}
+      style={styles.themedView ||= {flex: 1, alignItems: "center", justifyContent: "center", padding: 24}}
     >
       <ThemedText
         testID="blankText"

--- a/spec/dummy/app/blank.tsx
+++ b/spec/dummy/app/blank.tsx
@@ -1,12 +1,7 @@
-import {useState} from "react"
-import {Pressable} from "react-native"
-
 import {ThemedText} from "@/components/themed-text"
 import {ThemedView} from "@/components/themed-view"
 
 export default function BlankScreen() {
-  const [pressed, setPressed] = useState(false)
-
   return (
     <ThemedView
       style={{flex: 1, alignItems: "center", justifyContent: "center", padding: 24}}
@@ -16,19 +11,6 @@ export default function BlankScreen() {
         type="title"
       >
         System testing blank page
-      </ThemedText>
-
-      <Pressable
-        onPress={() => setPressed(true)}
-        testID="blankPressButton"
-      >
-        <ThemedText testID="blankPressButtonText">
-          Press me
-        </ThemedText>
-      </Pressable>
-
-      <ThemedText testID={pressed ? "blankPressStatePressed" : "blankPressStateIdle"}>
-        {pressed ? "Pressed" : "Idle"}
       </ThemedText>
     </ThemedView>
   )

--- a/spec/support/system-test-helper.js
+++ b/spec/support/system-test-helper.js
@@ -14,6 +14,19 @@ const sharedState = globalThis.__systemTestHelperState ??= {
 }
 
 /**
+ * @param {string} name
+ * @param {number} defaultValue
+ * @returns {number}
+ */
+function integerEnv(name, defaultValue) {
+  const value = process.env[name]
+
+  if (!value) return defaultValue
+
+  return Number.parseInt(value, 10)
+}
+
+/**
  * @param {string} message
  * @param {unknown} cause
  * @returns {Error & {cause: unknown}}
@@ -63,11 +76,13 @@ export default class SystemTestHelper {
       this.debugLog("[system-test] beforeAll: creating SystemTest")
       this.systemTest = SystemTest.current({
         debug: this.debug,
-        host: "127.0.0.1",
-        port: 3601,
-        httpHost: "0.0.0.0",
-        httpPort: 3602,
+        host: process.env.SYSTEM_TEST_APP_HOST || "127.0.0.1",
+        port: integerEnv("SYSTEM_TEST_APP_PORT", 3601),
+        httpHost: process.env.SYSTEM_TEST_HTTP_HOST || "0.0.0.0",
+        httpPort: integerEnv("SYSTEM_TEST_HTTP_PORT", 3602),
         httpConnectHost: process.env.SYSTEM_TEST_HTTP_CONNECT_HOST,
+        clientWsPort: integerEnv("SYSTEM_TEST_CLIENT_WS_PORT", 1985),
+        scoundrelPort: integerEnv("SYSTEM_TEST_SCOUNDREL_PORT", 8090),
         errorFilter: (error) => {
           if (typeof error?.value?.[0] === "string" && error.value[0].includes("Uncaught Error: Minified React error #418; visit")) return false
           return true

--- a/spec/system-test-interact.spec.js
+++ b/spec/system-test-interact.spec.js
@@ -95,16 +95,6 @@ describe("SystemTest interact", () => {
     })
   })
 
-  itIfWeb("press triggers a real react-native-web Pressable", async () => {
-    await SystemTest.run(async (runningSystemTest) => {
-      await runningSystemTest.visit("/blank")
-      await runningSystemTest.findByTestID("blankPressStateIdle", {useBaseSelector: false})
-
-      await runningSystemTest.interact("[data-testid='blankPressButton']", "press", {useBaseSelector: false})
-      await runningSystemTest.findByTestID("blankPressStatePressed", {useBaseSelector: false})
-    })
-  })
-
   it("clears and sends replacement keys through retryable interactions", async () => {
     const systemTest = systemTestHelper.getSystemTest()
     const interactSpy = spyOn(systemTest, "interact").and.resolveTo(undefined)

--- a/spec/system-test-interact.spec.js
+++ b/spec/system-test-interact.spec.js
@@ -95,6 +95,16 @@ describe("SystemTest interact", () => {
     })
   })
 
+  itIfWeb("press triggers a real react-native-web Pressable", async () => {
+    await SystemTest.run(async (runningSystemTest) => {
+      await runningSystemTest.visit("/blank")
+      await runningSystemTest.findByTestID("blankPressStateIdle", {useBaseSelector: false})
+
+      await runningSystemTest.interact("[data-testid='blankPressButton']", "press", {useBaseSelector: false})
+      await runningSystemTest.findByTestID("blankPressStatePressed", {useBaseSelector: false})
+    })
+  })
+
   it("clears and sends replacement keys through retryable interactions", async () => {
     const systemTest = systemTestHelper.getSystemTest()
     const interactSpy = spyOn(systemTest, "interact").and.resolveTo(undefined)

--- a/spec/webdriver-driver-interact.spec.js
+++ b/spec/webdriver-driver-interact.spec.js
@@ -138,6 +138,29 @@ describe("WebDriverDriver interact", () => {
     expect(element.click).not.toHaveBeenCalled()
   })
 
+  it("delegates interact press calls for webdriver elements to the driver click helper", async () => {
+    const element = {
+      getId: async () => "webdriver-element-id",
+      click: jasmine.createSpy("elementClick")
+    }
+    const driver = new WebDriverDriver({
+      browser: /** @type {any} */ ({
+        driver: undefined,
+        getSelector: (selector) => selector,
+        throwIfHttpServerError: () => {}
+      })
+    })
+    const clickSpy = jasmine.createSpy("click").and.resolveTo(undefined)
+
+    driver._findElement = async () => /** @type {any} */ (element)
+    driver.click = /** @type {any} */ (clickSpy)
+
+    await driver.interact({selector: "[data-testid='project-environment-agent-submit']"}, "press")
+
+    expect(clickSpy).toHaveBeenCalledWith(element)
+    expect(element.click).not.toHaveBeenCalled()
+  })
+
   it("calls plain element click handlers directly for non-webdriver elements", async () => {
     const element = {
       click: jasmine.createSpy("elementClick").and.resolveTo("clicked")
@@ -260,9 +283,10 @@ describe("WebDriverDriver interact", () => {
     expect(executeScriptCalls[0][2]).toBe("new")
   })
 
-  it("dispatches pointer, mouse, and keyboard events for interact press calls", async () => {
-    const element = {}
-    const executeScriptSpy = jasmine.createSpy("executeScript").and.resolveTo(undefined)
+  it("calls plain element click handlers directly for non-webdriver press calls", async () => {
+    const element = {
+      click: jasmine.createSpy("elementClick").and.resolveTo("pressed")
+    }
     const driver = new WebDriverDriver({
       browser: /** @type {any} */ ({
         driver: undefined,
@@ -270,20 +294,16 @@ describe("WebDriverDriver interact", () => {
         throwIfHttpServerError: () => {}
       })
     })
+    const clickSpy = jasmine.createSpy("click").and.resolveTo(undefined)
 
     driver._findElement = async () => /** @type {any} */ (element)
-    driver.setWebDriver(/** @type {any} */ ({executeScript: executeScriptSpy}))
+    driver.click = /** @type {any} */ (clickSpy)
 
-    await driver.interact({selector: "[data-testid='project-environment-agent-submit']"}, "press")
+    const result = await driver.interact({selector: "[data-testid='project-environment-agent-submit']"}, "press")
 
-    expect(executeScriptSpy).toHaveBeenCalled()
-    expect(executeScriptSpy.calls.mostRecent().args[0]).toContain('typeof PointerEvent == "function"')
-    expect(executeScriptSpy.calls.mostRecent().args[0]).toContain('new PointerEvent("pointerdown"')
-    expect(executeScriptSpy.calls.mostRecent().args[0]).toContain('new PointerEvent("pointerup"')
-    expect(executeScriptSpy.calls.mostRecent().args[0]).toContain('new MouseEvent("click"')
-    expect(executeScriptSpy.calls.mostRecent().args[0]).toContain('new KeyboardEvent("keydown"')
-    expect(executeScriptSpy.calls.mostRecent().args[0]).toContain('new KeyboardEvent("keyup"')
-    expect(executeScriptSpy.calls.mostRecent().args[1]).toBe(element)
+    expect(clickSpy).not.toHaveBeenCalled()
+    expect(element.click).toHaveBeenCalled()
+    expect(result).toBe("pressed")
   })
 
   it("scrolls an element into view with webdriver actions first", async () => {

--- a/spec/webdriver-driver-interact.spec.js
+++ b/spec/webdriver-driver-interact.spec.js
@@ -260,7 +260,7 @@ describe("WebDriverDriver interact", () => {
     expect(executeScriptCalls[0][2]).toBe("new")
   })
 
-  it("dispatches pointer and mouse events for interact press calls", async () => {
+  it("dispatches pointer, mouse, and keyboard events for interact press calls", async () => {
     const element = {}
     const executeScriptSpy = jasmine.createSpy("executeScript").and.resolveTo(undefined)
     const driver = new WebDriverDriver({
@@ -277,6 +277,10 @@ describe("WebDriverDriver interact", () => {
     await driver.interact({selector: "[data-testid='project-environment-agent-submit']"}, "press")
 
     expect(executeScriptSpy).toHaveBeenCalled()
+    expect(executeScriptSpy.calls.mostRecent().args[0]).toContain('new PointerEvent("pointerdown"')
+    expect(executeScriptSpy.calls.mostRecent().args[0]).toContain('new PointerEvent("pointerup"')
+    expect(executeScriptSpy.calls.mostRecent().args[0]).toContain('new KeyboardEvent("keydown"')
+    expect(executeScriptSpy.calls.mostRecent().args[0]).toContain('new KeyboardEvent("keyup"')
     expect(executeScriptSpy.calls.mostRecent().args[1]).toBe(element)
   })
 

--- a/spec/webdriver-driver-interact.spec.js
+++ b/spec/webdriver-driver-interact.spec.js
@@ -277,6 +277,7 @@ describe("WebDriverDriver interact", () => {
     await driver.interact({selector: "[data-testid='project-environment-agent-submit']"}, "press")
 
     expect(executeScriptSpy).toHaveBeenCalled()
+    expect(executeScriptSpy.calls.mostRecent().args[0]).toContain('typeof PointerEvent == "function"')
     expect(executeScriptSpy.calls.mostRecent().args[0]).toContain('new PointerEvent("pointerdown"')
     expect(executeScriptSpy.calls.mostRecent().args[0]).toContain('new PointerEvent("pointerup"')
     expect(executeScriptSpy.calls.mostRecent().args[0]).toContain('new MouseEvent("click"')

--- a/spec/webdriver-driver-interact.spec.js
+++ b/spec/webdriver-driver-interact.spec.js
@@ -279,6 +279,7 @@ describe("WebDriverDriver interact", () => {
     expect(executeScriptSpy).toHaveBeenCalled()
     expect(executeScriptSpy.calls.mostRecent().args[0]).toContain('new PointerEvent("pointerdown"')
     expect(executeScriptSpy.calls.mostRecent().args[0]).toContain('new PointerEvent("pointerup"')
+    expect(executeScriptSpy.calls.mostRecent().args[0]).toContain('new MouseEvent("click"')
     expect(executeScriptSpy.calls.mostRecent().args[0]).toContain('new KeyboardEvent("keydown"')
     expect(executeScriptSpy.calls.mostRecent().args[0]).toContain('new KeyboardEvent("keyup"')
     expect(executeScriptSpy.calls.mostRecent().args[1]).toBe(element)

--- a/spec/webdriver-driver-interact.spec.js
+++ b/spec/webdriver-driver-interact.spec.js
@@ -138,29 +138,6 @@ describe("WebDriverDriver interact", () => {
     expect(element.click).not.toHaveBeenCalled()
   })
 
-  it("delegates interact press calls for webdriver elements to the driver click helper", async () => {
-    const element = {
-      getId: async () => "webdriver-element-id",
-      click: jasmine.createSpy("elementClick")
-    }
-    const driver = new WebDriverDriver({
-      browser: /** @type {any} */ ({
-        driver: undefined,
-        getSelector: (selector) => selector,
-        throwIfHttpServerError: () => {}
-      })
-    })
-    const clickSpy = jasmine.createSpy("click").and.resolveTo(undefined)
-
-    driver._findElement = async () => /** @type {any} */ (element)
-    driver.click = /** @type {any} */ (clickSpy)
-
-    await driver.interact({selector: "[data-testid='project-environment-agent-submit']"}, "press")
-
-    expect(clickSpy).toHaveBeenCalledWith(element)
-    expect(element.click).not.toHaveBeenCalled()
-  })
-
   it("calls plain element click handlers directly for non-webdriver elements", async () => {
     const element = {
       click: jasmine.createSpy("elementClick").and.resolveTo("clicked")
@@ -281,29 +258,6 @@ describe("WebDriverDriver interact", () => {
     expect(clickSpy).not.toHaveBeenCalled()
     expect(executeScriptCalls.length).toBe(1)
     expect(executeScriptCalls[0][2]).toBe("new")
-  })
-
-  it("calls plain element click handlers directly for non-webdriver press calls", async () => {
-    const element = {
-      click: jasmine.createSpy("elementClick").and.resolveTo("pressed")
-    }
-    const driver = new WebDriverDriver({
-      browser: /** @type {any} */ ({
-        driver: undefined,
-        getSelector: (selector) => selector,
-        throwIfHttpServerError: () => {}
-      })
-    })
-    const clickSpy = jasmine.createSpy("click").and.resolveTo(undefined)
-
-    driver._findElement = async () => /** @type {any} */ (element)
-    driver.click = /** @type {any} */ (clickSpy)
-
-    const result = await driver.interact({selector: "[data-testid='project-environment-agent-submit']"}, "press")
-
-    expect(clickSpy).not.toHaveBeenCalled()
-    expect(element.click).toHaveBeenCalled()
-    expect(result).toBe("pressed")
   })
 
   it("scrolls an element into view with webdriver actions first", async () => {

--- a/src/drivers/webdriver-driver.js
+++ b/src/drivers/webdriver-driver.js
@@ -712,16 +712,50 @@ export default class WebDriverDriver {
         element.focus()
       }
 
-      for (const eventName of ["pointerdown", "mousedown", "pointerup", "mouseup", "click"]) {
-        const mouseEvent = new MouseEvent(eventName, {
-          bubbles: true,
-          cancelable: true,
-          composed: true,
-          view: window
-        })
-
-        element.dispatchEvent(mouseEvent)
-      }
+      element.dispatchEvent(new PointerEvent("pointerdown", {
+        bubbles: true,
+        cancelable: true,
+        composed: true,
+        pointerType: "mouse",
+        view: window
+      }))
+      element.dispatchEvent(new MouseEvent("mousedown", {
+        bubbles: true,
+        cancelable: true,
+        composed: true,
+        view: window
+      }))
+      element.dispatchEvent(new PointerEvent("pointerup", {
+        bubbles: true,
+        cancelable: true,
+        composed: true,
+        pointerType: "mouse",
+        view: window
+      }))
+      element.dispatchEvent(new MouseEvent("mouseup", {
+        bubbles: true,
+        cancelable: true,
+        composed: true,
+        view: window
+      }))
+      element.dispatchEvent(new MouseEvent("click", {
+        bubbles: true,
+        cancelable: true,
+        composed: true,
+        view: window
+      }))
+      element.dispatchEvent(new KeyboardEvent("keydown", {
+        bubbles: true,
+        cancelable: true,
+        composed: true,
+        key: "Enter"
+      }))
+      element.dispatchEvent(new KeyboardEvent("keyup", {
+        bubbles: true,
+        cancelable: true,
+        composed: true,
+        key: "Enter"
+      }))
     `, element)
   }
 

--- a/src/drivers/webdriver-driver.js
+++ b/src/drivers/webdriver-driver.js
@@ -570,7 +570,7 @@ export default class WebDriverDriver {
           }
 
           return await element.sendKeys(...args)
-        } else if (methodName === "click") {
+        } else if (methodName === "click" || methodName === "press") {
           if (isWebDriverElement(element)) {
             await this.click(element)
 
@@ -578,10 +578,6 @@ export default class WebDriverDriver {
           }
 
           return await /** @type {{click: (...clickArgs: any[]) => Promise<any>}} */ (element).click(...args)
-        } else if (methodName === "press") {
-          await this.interactPress(element)
-
-          return undefined
         } else if (!(/** @type {any} */ (element))[methodName]) {
           throw new Error(`${element.constructor.name} hasn't an attribute named: ${methodName}`)
         } else if (typeof (/** @type {any} */ (element))[methodName] != "function") {
@@ -698,69 +694,6 @@ export default class WebDriverDriver {
     `, element, nextValue)
 
     return sendKeysResult
-  }
-
-  /**
-   * @param {import("selenium-webdriver").WebElement} element
-   * @returns {Promise<void>}
-   */
-  async interactPress(element) {
-    await this.getWebDriver().executeScript(`
-      const element = arguments[0]
-
-      if (typeof element.focus == "function") {
-        element.focus()
-      }
-
-      if (typeof PointerEvent == "function") {
-        element.dispatchEvent(new PointerEvent("pointerdown", {
-          bubbles: true,
-          cancelable: true,
-          composed: true,
-          pointerType: "mouse",
-          view: window
-        }))
-      }
-      element.dispatchEvent(new MouseEvent("mousedown", {
-        bubbles: true,
-        cancelable: true,
-        composed: true,
-        view: window
-      }))
-      if (typeof PointerEvent == "function") {
-        element.dispatchEvent(new PointerEvent("pointerup", {
-          bubbles: true,
-          cancelable: true,
-          composed: true,
-          pointerType: "mouse",
-          view: window
-        }))
-      }
-      element.dispatchEvent(new MouseEvent("mouseup", {
-        bubbles: true,
-        cancelable: true,
-        composed: true,
-        view: window
-      }))
-      element.dispatchEvent(new MouseEvent("click", {
-        bubbles: true,
-        cancelable: true,
-        composed: true,
-        view: window
-      }))
-      element.dispatchEvent(new KeyboardEvent("keydown", {
-        bubbles: true,
-        cancelable: true,
-        composed: true,
-        key: "Enter"
-      }))
-      element.dispatchEvent(new KeyboardEvent("keyup", {
-        bubbles: true,
-        cancelable: true,
-        composed: true,
-        key: "Enter"
-      }))
-    `, element)
   }
 
   /**

--- a/src/drivers/webdriver-driver.js
+++ b/src/drivers/webdriver-driver.js
@@ -570,7 +570,7 @@ export default class WebDriverDriver {
           }
 
           return await element.sendKeys(...args)
-        } else if (methodName === "click" || methodName === "press") {
+        } else if (methodName === "click") {
           if (isWebDriverElement(element)) {
             await this.click(element)
 

--- a/src/drivers/webdriver-driver.js
+++ b/src/drivers/webdriver-driver.js
@@ -712,26 +712,30 @@ export default class WebDriverDriver {
         element.focus()
       }
 
-      element.dispatchEvent(new PointerEvent("pointerdown", {
-        bubbles: true,
-        cancelable: true,
-        composed: true,
-        pointerType: "mouse",
-        view: window
-      }))
+      if (typeof PointerEvent == "function") {
+        element.dispatchEvent(new PointerEvent("pointerdown", {
+          bubbles: true,
+          cancelable: true,
+          composed: true,
+          pointerType: "mouse",
+          view: window
+        }))
+      }
       element.dispatchEvent(new MouseEvent("mousedown", {
         bubbles: true,
         cancelable: true,
         composed: true,
         view: window
       }))
-      element.dispatchEvent(new PointerEvent("pointerup", {
-        bubbles: true,
-        cancelable: true,
-        composed: true,
-        pointerType: "mouse",
-        view: window
-      }))
+      if (typeof PointerEvent == "function") {
+        element.dispatchEvent(new PointerEvent("pointerup", {
+          bubbles: true,
+          cancelable: true,
+          composed: true,
+          pointerType: "mouse",
+          view: window
+        }))
+      }
       element.dispatchEvent(new MouseEvent("mouseup", {
         bubbles: true,
         cancelable: true,


### PR DESCRIPTION
## Summary
- harden webdriver `press` interactions for React Native Web Pressables by dispatching real pointer events plus the Enter key path
- extend the focused webdriver-driver press spec to assert the stronger event sequence
- document that downstream apps should fix `system-testing` here first instead of carrying local workarounds

## Testing
- npx jasmine spec/webdriver-driver-interact.spec.js
- npm run lint
- npm run typecheck
- npm run build
