### PR TITLE
Scroll targets into view before WebDriver action clicks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@
 - Keep single-tag JSDoc blocks on one line when they fit (for example `/** @returns {string | undefined} */`).
 - Keep `if`/`else if` conditions on one line when they fit within 160 characters.
 - Avoid putting condition logic inside assignment expressions; prefer explicit `if/else` branches.
+- When typed option objects are required by contract, pass through explicit provided values and let unsupported values fail loudly at the callee; do not silently narrow or drop invalid values just to keep going.
 - In system tests, when the next step is `interact(...)`, prefer selector-based `interact("[data-testid='...']", ...)` calls over finding a throwaway element handle first so retry/error handling stays active.
 - In system tests, if a spec needs the click-clear-sendKeys input flow, add or use a shared package helper on `Browser`/`SystemTest` (for example `clearAndSendKeys(...)`) instead of open-coding that sequence in individual specs.
 - In system tests, if a spec needs to scroll an offscreen element into view, add or use a shared package helper on `Browser`/`SystemTest` (for example `scrollIntoView(...)` / `scrollTestIdIntoView(...)`) instead of project-local DOM query wrappers.

--- a/changelog.d/20260412-webdriver-click-scroll-before-actions.md
+++ b/changelog.d/20260412-webdriver-click-scroll-before-actions.md
@@ -1,1 +1,1 @@
-Ensure WebDriver click scrolls the target into view before running the pointer-action click sequence.
+Allow WebDriver click helpers to opt into scrolling targets into view before running the pointer-action click sequence.

--- a/changelog.d/20260412-webdriver-click-scroll-before-actions.md
+++ b/changelog.d/20260412-webdriver-click-scroll-before-actions.md
@@ -1,1 +1,1 @@
-Allow WebDriver click helpers to opt into scrolling targets into view before running the pointer-action click sequence.
+Keep WebDriver clicks on normal Selenium `element.click()` by default, while allowing callers to opt into `{method: "actions", scrollTo: true}` for pointer-action clicks that need pre-scroll alignment.

--- a/changelog.d/20260412-webdriver-click-scroll-before-actions.md
+++ b/changelog.d/20260412-webdriver-click-scroll-before-actions.md
@@ -1,0 +1,1 @@
+Ensure WebDriver click scrolls the target into view before running the pointer-action click sequence.

--- a/spec/webdriver-driver-interact.spec.js
+++ b/spec/webdriver-driver-interact.spec.js
@@ -138,6 +138,93 @@ describe("WebDriverDriver interact", () => {
     expect(element.click).not.toHaveBeenCalled()
   })
 
+  it("passes scrollTo through interact click calls for webdriver elements", async () => {
+    const element = {
+      getId: async () => "webdriver-element-id",
+      click: jasmine.createSpy("elementClick")
+    }
+    const driver = new WebDriverDriver({
+      browser: /** @type {any} */ ({
+        driver: undefined,
+        getSelector: (selector) => selector,
+        throwIfHttpServerError: () => {}
+      })
+    })
+    const clickSpy = jasmine.createSpy("click").and.resolveTo(undefined)
+
+    driver._findElement = async () => /** @type {any} */ (element)
+    driver.click = /** @type {any} */ (clickSpy)
+
+    await driver.interact({selector: "[data-testid='project-environment-agent-submit']", scrollTo: true}, "click")
+
+    expect(clickSpy).toHaveBeenCalledWith(element, {scrollTo: true})
+    expect(element.click).not.toHaveBeenCalled()
+  })
+
+  it("does not scroll webdriver clicks into view unless explicitly requested", async () => {
+    const element = {
+      getId: async () => "webdriver-element-id"
+    }
+    /** @type {{click: jasmine.Spy, move: jasmine.Spy, perform: jasmine.Spy}} */
+    const actions = /** @type {any} */ ({})
+    actions.click = jasmine.createSpy("click").and.returnValue(actions)
+    actions.move = jasmine.createSpy("move").and.returnValue(actions)
+    actions.perform = jasmine.createSpy("perform").and.resolveTo(undefined)
+    const driver = new WebDriverDriver({
+      browser: /** @type {any} */ ({
+        driver: undefined,
+        getSelector: (selector) => selector,
+        throwIfHttpServerError: () => {}
+      })
+    })
+    const scrollSpy = jasmine.createSpy("scrollElementIntoView").and.resolveTo(undefined)
+
+    driver._findElement = async () => /** @type {any} */ (element)
+    driver.scrollElementIntoView = /** @type {any} */ (scrollSpy)
+    driver.setWebDriver(/** @type {any} */ ({
+      actions: () => actions
+    }))
+
+    await driver.click(element)
+
+    expect(scrollSpy).not.toHaveBeenCalled()
+    expect(actions.move).toHaveBeenCalledWith({origin: element})
+    expect(actions.click).toHaveBeenCalled()
+    expect(actions.perform).toHaveBeenCalled()
+  })
+
+  it("scrolls webdriver clicks into view when requested", async () => {
+    const element = {
+      getId: async () => "webdriver-element-id"
+    }
+    /** @type {{click: jasmine.Spy, move: jasmine.Spy, perform: jasmine.Spy}} */
+    const actions = /** @type {any} */ ({})
+    actions.click = jasmine.createSpy("click").and.returnValue(actions)
+    actions.move = jasmine.createSpy("move").and.returnValue(actions)
+    actions.perform = jasmine.createSpy("perform").and.resolveTo(undefined)
+    const driver = new WebDriverDriver({
+      browser: /** @type {any} */ ({
+        driver: undefined,
+        getSelector: (selector) => selector,
+        throwIfHttpServerError: () => {}
+      })
+    })
+    const scrollSpy = jasmine.createSpy("scrollElementIntoView").and.resolveTo(undefined)
+
+    driver._findElement = async () => /** @type {any} */ (element)
+    driver.scrollElementIntoView = /** @type {any} */ (scrollSpy)
+    driver.setWebDriver(/** @type {any} */ ({
+      actions: () => actions
+    }))
+
+    await driver.click(element, {scrollTo: true})
+
+    expect(scrollSpy).toHaveBeenCalledWith(element)
+    expect(actions.move).toHaveBeenCalledWith({origin: element})
+    expect(actions.click).toHaveBeenCalled()
+    expect(actions.perform).toHaveBeenCalled()
+  })
+
   it("calls plain element click handlers directly for non-webdriver elements", async () => {
     const element = {
       click: jasmine.createSpy("elementClick").and.resolveTo("clicked")

--- a/spec/webdriver-driver-interact.spec.js
+++ b/spec/webdriver-driver-interact.spec.js
@@ -134,7 +134,7 @@ describe("WebDriverDriver interact", () => {
 
     await driver.interact({selector: "[data-testid='project-environment-agent-submit']"}, "click")
 
-    expect(clickSpy).toHaveBeenCalledWith(element)
+    expect(clickSpy).toHaveBeenCalledWith(element, {})
     expect(element.click).not.toHaveBeenCalled()
   })
 

--- a/spec/webdriver-driver-interact.spec.js
+++ b/spec/webdriver-driver-interact.spec.js
@@ -161,7 +161,102 @@ describe("WebDriverDriver interact", () => {
     expect(element.click).not.toHaveBeenCalled()
   })
 
-  it("does not scroll webdriver clicks into view unless explicitly requested", async () => {
+  it("passes the actions click method through interact click calls for webdriver elements", async () => {
+    const element = {
+      getId: async () => "webdriver-element-id",
+      click: jasmine.createSpy("elementClick")
+    }
+    const driver = new WebDriverDriver({
+      browser: /** @type {any} */ ({
+        driver: undefined,
+        getSelector: (selector) => selector,
+        throwIfHttpServerError: () => {}
+      })
+    })
+    const clickSpy = jasmine.createSpy("click").and.resolveTo(undefined)
+
+    driver._findElement = async () => /** @type {any} */ (element)
+    driver.click = /** @type {any} */ (clickSpy)
+
+    await driver.interact({selector: "[data-testid='project-environment-agent-submit']", method: "actions", scrollTo: true}, "click")
+
+    expect(clickSpy).toHaveBeenCalledWith(element, {method: "actions", scrollTo: true})
+    expect(element.click).not.toHaveBeenCalled()
+  })
+
+  it("uses a plain element click by default", async () => {
+    const element = {
+      click: jasmine.createSpy("elementClick").and.resolveTo(undefined),
+      getId: async () => "webdriver-element-id"
+    }
+    const driver = new WebDriverDriver({
+      browser: /** @type {any} */ ({
+        driver: undefined,
+        getSelector: (selector) => selector,
+        throwIfHttpServerError: () => {}
+      })
+    })
+    const scrollSpy = jasmine.createSpy("scrollElementIntoView").and.resolveTo(undefined)
+    const actionsSpy = jasmine.createSpy("actions")
+
+    driver._findElement = async () => /** @type {any} */ (element)
+    driver.scrollElementIntoView = /** @type {any} */ (scrollSpy)
+    driver.setWebDriver(/** @type {any} */ ({actions: actionsSpy}))
+
+    await driver.click(element)
+
+    expect(scrollSpy).not.toHaveBeenCalled()
+    expect(actionsSpy).not.toHaveBeenCalled()
+    expect(element.click).toHaveBeenCalled()
+  })
+
+  it("does not scroll normal webdriver clicks into view unless explicitly requested", async () => {
+    const element = {
+      click: jasmine.createSpy("elementClick").and.resolveTo(undefined),
+      getId: async () => "webdriver-element-id"
+    }
+    const driver = new WebDriverDriver({
+      browser: /** @type {any} */ ({
+        driver: undefined,
+        getSelector: (selector) => selector,
+        throwIfHttpServerError: () => {}
+      })
+    })
+    const scrollSpy = jasmine.createSpy("scrollElementIntoView").and.resolveTo(undefined)
+
+    driver._findElement = async () => /** @type {any} */ (element)
+    driver.scrollElementIntoView = /** @type {any} */ (scrollSpy)
+
+    await driver.click(element)
+
+    expect(scrollSpy).not.toHaveBeenCalled()
+    expect(element.click).toHaveBeenCalled()
+  })
+
+  it("scrolls normal webdriver clicks into view when requested", async () => {
+    const element = {
+      click: jasmine.createSpy("elementClick").and.resolveTo(undefined),
+      getId: async () => "webdriver-element-id"
+    }
+    const driver = new WebDriverDriver({
+      browser: /** @type {any} */ ({
+        driver: undefined,
+        getSelector: (selector) => selector,
+        throwIfHttpServerError: () => {}
+      })
+    })
+    const scrollSpy = jasmine.createSpy("scrollElementIntoView").and.resolveTo(undefined)
+
+    driver._findElement = async () => /** @type {any} */ (element)
+    driver.scrollElementIntoView = /** @type {any} */ (scrollSpy)
+
+    await driver.click(element, {scrollTo: true})
+
+    expect(scrollSpy).toHaveBeenCalledWith(element)
+    expect(element.click).toHaveBeenCalled()
+  })
+
+  it("does not scroll webdriver action clicks into view unless explicitly requested", async () => {
     const element = {
       getId: async () => "webdriver-element-id"
     }
@@ -185,7 +280,7 @@ describe("WebDriverDriver interact", () => {
       actions: () => actions
     }))
 
-    await driver.click(element)
+    await driver.click(element, {method: "actions"})
 
     expect(scrollSpy).not.toHaveBeenCalled()
     expect(actions.move).toHaveBeenCalledWith({origin: element})
@@ -193,7 +288,7 @@ describe("WebDriverDriver interact", () => {
     expect(actions.perform).toHaveBeenCalled()
   })
 
-  it("scrolls webdriver clicks into view when requested", async () => {
+  it("scrolls webdriver action clicks into view when requested", async () => {
     const element = {
       getId: async () => "webdriver-element-id"
     }
@@ -217,7 +312,7 @@ describe("WebDriverDriver interact", () => {
       actions: () => actions
     }))
 
-    await driver.click(element, {scrollTo: true})
+    await driver.click(element, {method: "actions", scrollTo: true})
 
     expect(scrollSpy).toHaveBeenCalledWith(element)
     expect(actions.move).toHaveBeenCalledWith({origin: element})

--- a/src/drivers/webdriver-driver.js
+++ b/src/drivers/webdriver-driver.js
@@ -94,6 +94,7 @@ function getSendKeysUsesSelectAllAndDelete(...args) {
  * @typedef {object} FindArgs
  * @property {number} [timeout] Override timeout for lookup.
  * @property {boolean | null} [visible] Whether to require elements to be visible (`true`) or hidden (`false`). Use `null` to disable visibility filtering.
+ * @property {"actions"} [method] Use the Selenium Actions API instead of a normal element click.
  * @property {boolean} [scrollTo] Whether to scroll found elements into view before returning them.
  * @property {boolean} [useBaseSelector] Whether to scope by the base selector.
  */
@@ -486,7 +487,7 @@ export default class WebDriverDriver {
    * @returns {Promise<void>}
    */
   async click(elementOrIdentifier, args) {
-    const {scrollTo = false} = args || {}
+    const {method, scrollTo = false} = args || {}
     let tries = 0
 
     while (true) {
@@ -499,7 +500,12 @@ export default class WebDriverDriver {
           await this.scrollElementIntoView(element)
         }
 
-        await this.getWebDriver().actions({async: true}).move({origin: element}).click().perform()
+        if (method === "actions") {
+          await this.getWebDriver().actions({async: true}).move({origin: element}).click().perform()
+        } else {
+          await element.click()
+        }
+
         break
       } catch (error) {
         if (error instanceof Error) {
@@ -576,12 +582,18 @@ export default class WebDriverDriver {
           return await element.sendKeys(...args)
         } else if (methodName === "click") {
           if (isWebDriverElement(element)) {
-            const clickArgs = typeof elementOrIdentifier === "object" &&
-              elementOrIdentifier &&
-              !isWebDriverElement(elementOrIdentifier) &&
-              elementOrIdentifier.scrollTo
-              ? {scrollTo: true}
-              : undefined
+            /** @type {FindArgs | undefined} */
+            let clickArgs
+
+            if (typeof elementOrIdentifier === "object" && elementOrIdentifier && !isWebDriverElement(elementOrIdentifier)) {
+              if (elementOrIdentifier.method === "actions" && elementOrIdentifier.scrollTo) {
+                clickArgs = {method: "actions", scrollTo: true}
+              } else if (elementOrIdentifier.method === "actions") {
+                clickArgs = {method: "actions"}
+              } else if (elementOrIdentifier.scrollTo) {
+                clickArgs = {scrollTo: true}
+              }
+            }
 
             if (clickArgs) {
               await this.click(element, clickArgs)

--- a/src/drivers/webdriver-driver.js
+++ b/src/drivers/webdriver-driver.js
@@ -502,8 +502,10 @@ export default class WebDriverDriver {
 
         if (method === "actions") {
           await this.getWebDriver().actions({async: true}).move({origin: element}).click().perform()
-        } else {
+        } else if (method === undefined) {
           await element.click()
+        } else {
+          throw new Error(`Unknown method: ${method}`)
         }
 
         break
@@ -582,24 +584,14 @@ export default class WebDriverDriver {
           return await element.sendKeys(...args)
         } else if (methodName === "click") {
           if (isWebDriverElement(element)) {
-            /** @type {FindArgs | undefined} */
-            let clickArgs
-
+            /** @type {FindArgs} */
+            const clickArgs = {}
             if (typeof elementOrIdentifier === "object" && elementOrIdentifier && !isWebDriverElement(elementOrIdentifier)) {
-              if (elementOrIdentifier.method === "actions" && elementOrIdentifier.scrollTo) {
-                clickArgs = {method: "actions", scrollTo: true}
-              } else if (elementOrIdentifier.method === "actions") {
-                clickArgs = {method: "actions"}
-              } else if (elementOrIdentifier.scrollTo) {
-                clickArgs = {scrollTo: true}
-              }
+              if (elementOrIdentifier.method !== undefined) clickArgs.method = elementOrIdentifier.method
+              if (elementOrIdentifier.scrollTo !== undefined) clickArgs.scrollTo = elementOrIdentifier.scrollTo
             }
 
-            if (clickArgs) {
-              await this.click(element, clickArgs)
-            } else {
-              await this.click(element)
-            }
+            await this.click(element, clickArgs)
 
             return undefined
           }

--- a/src/drivers/webdriver-driver.js
+++ b/src/drivers/webdriver-driver.js
@@ -486,6 +486,7 @@ export default class WebDriverDriver {
    * @returns {Promise<void>}
    */
   async click(elementOrIdentifier, args) {
+    const {scrollTo = false} = args || {}
     let tries = 0
 
     while (true) {
@@ -494,7 +495,10 @@ export default class WebDriverDriver {
       try {
         const element = await this._findElement(elementOrIdentifier, args)
 
-        await this.scrollElementIntoView(element)
+        if (scrollTo) {
+          await this.scrollElementIntoView(element)
+        }
+
         await this.getWebDriver().actions({async: true}).move({origin: element}).click().perform()
         break
       } catch (error) {
@@ -572,7 +576,18 @@ export default class WebDriverDriver {
           return await element.sendKeys(...args)
         } else if (methodName === "click") {
           if (isWebDriverElement(element)) {
-            await this.click(element)
+            const clickArgs = typeof elementOrIdentifier === "object" &&
+              elementOrIdentifier &&
+              !isWebDriverElement(elementOrIdentifier) &&
+              elementOrIdentifier.scrollTo
+              ? {scrollTo: true}
+              : undefined
+
+            if (clickArgs) {
+              await this.click(element, clickArgs)
+            } else {
+              await this.click(element)
+            }
 
             return undefined
           }

--- a/src/drivers/webdriver-driver.js
+++ b/src/drivers/webdriver-driver.js
@@ -493,9 +493,9 @@ export default class WebDriverDriver {
 
       try {
         const element = await this._findElement(elementOrIdentifier, args)
-        const actions = this.getWebDriver().actions({async: true})
 
-        await actions.move({origin: element}).click().perform()
+        await this.scrollElementIntoView(element)
+        await this.getWebDriver().actions({async: true}).move({origin: element}).click().perform()
         break
       } catch (error) {
         if (error instanceof Error) {

--- a/src/system-test.js
+++ b/src/system-test.js
@@ -33,6 +33,7 @@ import Browser from "./browser.js"
  * @typedef {object} FindArgs
  * @property {number} [timeout] Override timeout for lookup.
  * @property {boolean | null} [visible] Whether to require elements to be visible (`true`) or hidden (`false`). Use `null` to disable visibility filtering.
+ * @property {"actions"} [method] Use the Selenium Actions API instead of a normal element click.
  * @property {boolean} [scrollTo] Whether to scroll found elements into view before returning them.
  * @property {boolean} [useBaseSelector] Whether to scope by the base selector.
  */


### PR DESCRIPTION
## Summary
- keep normal WebDriver clicks on plain Selenium `element.click()` by default
- add an explicit `{method: "actions"}` click path for pointer-action clicks
- allow optional `scrollTo: true` with either click method
- cover default and action click behavior with regression specs

## Testing
- npm run typecheck
- npx jasmine spec/webdriver-driver-interact.spec.js