### PR TITLE
Fix RN Web pressable clicks in WebDriver

### DIFF
--- a/spec/webdriver-driver-interact.spec.js
+++ b/spec/webdriver-driver-interact.spec.js
@@ -208,6 +208,27 @@ describe("WebDriverDriver interact", () => {
     expect(clickSpy).toHaveBeenCalledWith(element, {method: "actions", scrollTo: true})
   })
 
+  it("strips method before selector lookup in _findElement", async () => {
+    const element = {
+      getId: async () => "webdriver-element-id",
+      click: jasmine.createSpy("elementClick")
+    }
+    const driver = new WebDriverDriver({
+      browser: /** @type {any} */ ({
+        driver: undefined,
+        getSelector: (selector) => selector,
+        throwIfHttpServerError: () => {}
+      })
+    })
+    const findSpy = jasmine.createSpy("find").and.resolveTo(element)
+
+    driver.find = /** @type {any} */ (findSpy)
+
+    await driver._findElement({selector: "[data-testid='project-environment-agent-submit']", method: "actions", scrollTo: true})
+
+    expect(findSpy).toHaveBeenCalledWith("[data-testid='project-environment-agent-submit']", {scrollTo: true})
+  })
+
   it("passes scrollTo through to the element lookup for non-click interact methods", async () => {
     const element = {
       getAttribute: async () => "",
@@ -229,6 +250,32 @@ describe("WebDriverDriver interact", () => {
     await driver.interact({selector: "textarea[data-testid='project-environment-agent-input']", scrollTo: true}, "sendKeys", "pwd")
 
     expect(findSpy).toHaveBeenCalledWith("textarea[data-testid='project-environment-agent-input']", {scrollTo: true})
+  })
+
+  it("uses the DOM press sequence for div pressables with tabindex", async () => {
+    const element = {
+      click: jasmine.createSpy("elementClick").and.resolveTo(undefined),
+      getAttribute: jasmine.createSpy("getAttribute").and.callFake(async (name) => name === "tabindex" ? "0" : null),
+      getId: async () => "webdriver-element-id",
+      getTagName: async () => "div"
+    }
+    const driver = new WebDriverDriver({
+      browser: /** @type {any} */ ({
+        driver: undefined,
+        getSelector: (selector) => selector,
+        throwIfHttpServerError: () => {}
+      })
+    })
+    const executeScriptSpy = jasmine.createSpy("executeScript").and.resolveTo(undefined)
+
+    driver._findElement = async () => /** @type {any} */ (element)
+    driver.setWebDriver(/** @type {any} */ ({executeScript: executeScriptSpy}))
+
+    await driver.click(element)
+
+    expect(executeScriptSpy).toHaveBeenCalled()
+    expect(executeScriptSpy.calls.mostRecent().args[1]).toBe(element)
+    expect(element.click).not.toHaveBeenCalled()
   })
 
   it("uses a plain element click by default", async () => {

--- a/src/drivers/webdriver-driver.js
+++ b/src/drivers/webdriver-driver.js
@@ -455,6 +455,7 @@ export default class WebDriverDriver {
       const {selector, ...restArgs} = elementOrIdentifier
 
       delete restArgs.withFallback
+      delete restArgs.method
 
       element = await this.find(selector, restArgs)
     } else {
@@ -500,7 +501,9 @@ export default class WebDriverDriver {
           await this.scrollElementIntoView(element)
         }
 
-        if (method === "actions") {
+        if (await this.shouldUseDomPressSequence(element)) {
+          await this.dispatchDomPressSequence(element)
+        } else if (method === "actions") {
           await this.getWebDriver().actions({async: true}).move({origin: element}).click().perform()
         } else if (method === undefined) {
           await element.click()
@@ -535,6 +538,64 @@ export default class WebDriverDriver {
    */
   async scrollElementIntoView(element) {
     await this.getWebDriver().actions({async: true}).move({origin: element}).perform()
+  }
+
+  /**
+   * Uses a DOM press sequence for React Native Web pressables that Selenium can focus
+   * without actually triggering their `onPress` handlers.
+   * @param {import("selenium-webdriver").WebElement} element
+   * @returns {Promise<boolean>}
+   */
+  async shouldUseDomPressSequence(element) {
+    if (typeof element.getTagName !== "function" || typeof element.getAttribute !== "function") return false
+
+    const tagName = await element.getTagName()
+
+    if (tagName !== "div") return false
+
+    const tabIndex = await element.getAttribute("tabindex")
+
+    return tabIndex !== null
+  }
+
+  /**
+   * Dispatches the full pointer/mouse/click event sequence on the element.
+   * @param {import("selenium-webdriver").WebElement} element
+   * @returns {Promise<void>}
+   */
+  async dispatchDomPressSequence(element) {
+    await this.getWebDriver().executeScript(`
+      const element = arguments[0]
+      const rect = element.getBoundingClientRect()
+      const clientX = rect.left + rect.width / 2
+      const clientY = rect.top + rect.height / 2
+      const baseEvent = {
+        bubbles: true,
+        cancelable: true,
+        composed: true,
+        button: 0,
+        buttons: 1,
+        clientX,
+        clientY,
+        detail: 1,
+        view: window
+      }
+
+      if (typeof element.focus === "function") element.focus()
+
+      if (typeof PointerEvent === "function") {
+        element.dispatchEvent(new PointerEvent("pointerdown", {...baseEvent, pointerId: 1, pointerType: "mouse", isPrimary: true}))
+      }
+
+      element.dispatchEvent(new MouseEvent("mousedown", baseEvent))
+
+      if (typeof PointerEvent === "function") {
+        element.dispatchEvent(new PointerEvent("pointerup", {...baseEvent, buttons: 0, pointerId: 1, pointerType: "mouse", isPrimary: true}))
+      }
+
+      element.dispatchEvent(new MouseEvent("mouseup", {...baseEvent, buttons: 0}))
+      element.dispatchEvent(new MouseEvent("click", {...baseEvent, buttons: 0}))
+    `, element)
   }
 
   /**


### PR DESCRIPTION
## Summary
- strip interact-only click args before selector lookup
- dispatch a DOM press sequence for RN Web pressable divs with tabindex
- cover the WebDriver regression with focused specs

## Testing
- npm run lint
- npm run typecheck
- npx jasmine spec/webdriver-driver-interact.spec.js