### PR TITLE
Filter Chrome password form browser warning

### DIFF
--- a/scripts/test-appium-web.js
+++ b/scripts/test-appium-web.js
@@ -55,14 +55,9 @@ export async function main() {
   })
 
   await run("npm", ["test"], {
-    env: {
-      ...process.env,
-      SYSTEM_TEST_HOST: "dist",
-      SYSTEM_TEST_DRIVER: "appium",
-      SYSTEM_TEST_APPIUM_DRIVERS: "chromium",
-      SYSTEM_TEST_APPIUM_TEST_ID_STRATEGY: "css",
-      SYSTEM_TEST_APPIUM_CAPABILITIES: JSON.stringify(capabilities)
-    }
+    env: buildAppiumWebTestEnv({
+      capabilities
+    })
   })
 }
 
@@ -198,6 +193,26 @@ export function buildAppiumWebCapabilities({chromeBinary, chromedriverPath}) {
       binary: chromeBinary,
       args: ["--headless=new", "--no-sandbox", "--disable-dev-shm-usage", "--disable-gpu"]
     }
+  }
+}
+
+
+/**
+ * @param {{
+ *   capabilities: Record<string, unknown>,
+ *   baseEnv?: Record<string, string | undefined>
+ * }} args
+ * @returns {Record<string, string | undefined>}
+ */
+export function buildAppiumWebTestEnv({capabilities, baseEnv = process.env}) {
+  return {
+    ...baseEnv,
+    SYSTEM_TEST_HOST: "dist",
+    SYSTEM_TEST_HTTP_CONNECT_HOST: "127.0.0.1",
+    SYSTEM_TEST_DRIVER: "appium",
+    SYSTEM_TEST_APPIUM_DRIVERS: "chromium",
+    SYSTEM_TEST_APPIUM_TEST_ID_STRATEGY: "css",
+    SYSTEM_TEST_APPIUM_CAPABILITIES: JSON.stringify(capabilities)
   }
 }
 

--- a/spec/test-appium-web.spec.js
+++ b/spec/test-appium-web.spec.js
@@ -1,4 +1,4 @@
-import {buildAppiumWebCapabilities, resolveChromedriverDownload} from "../scripts/test-appium-web.js"
+import {buildAppiumWebCapabilities, buildAppiumWebTestEnv, resolveChromedriverDownload} from "../scripts/test-appium-web.js"
 
 describe("test-appium-web helpers", () => {
   it("prefers the closest matching chromedriver for the current Chrome build", () => {
@@ -88,5 +88,22 @@ describe("test-appium-web helpers", () => {
         args: ["--headless=new", "--no-sandbox", "--disable-dev-shm-usage", "--disable-gpu"]
       }
     })
+  })
+
+  it("forces localhost as the dist HTTP connect host for Appium web runs", () => {
+    const env = buildAppiumWebTestEnv({
+      capabilities: {browserName: "chrome"},
+      baseEnv: {SYSTEM_TEST_HTTP_CONNECT_HOST: "10.0.2.2", PATH: "/usr/bin"}
+    })
+
+    expect(env).toEqual(jasmine.objectContaining({
+      PATH: "/usr/bin",
+      SYSTEM_TEST_HOST: "dist",
+      SYSTEM_TEST_HTTP_CONNECT_HOST: "127.0.0.1",
+      SYSTEM_TEST_DRIVER: "appium",
+      SYSTEM_TEST_APPIUM_DRIVERS: "chromium",
+      SYSTEM_TEST_APPIUM_TEST_ID_STRATEGY: "css",
+      SYSTEM_TEST_APPIUM_CAPABILITIES: JSON.stringify({browserName: "chrome"})
+    }))
   })
 })

--- a/spec/webdriver-driver-interact.spec.js
+++ b/spec/webdriver-driver-interact.spec.js
@@ -553,4 +553,27 @@ describe("WebDriverDriver interact", () => {
     expect(performSpy).toHaveBeenCalled()
     expect(executeScriptSpy).not.toHaveBeenCalled()
   })
+
+  it("filters the known Chrome password-not-in-form warning from browser logs", async () => {
+    const driver = new WebDriverDriver({
+      browser: /** @type {any} */ ({
+        driver: undefined,
+        getSelector: (selector) => selector,
+        throwIfHttpServerError: () => {}
+      })
+    })
+
+    driver.setWebDriver(/** @type {any} */ ({
+      manage: () => ({
+        logs: () => ({
+          get: async () => ([
+            {level: {name: "DEBUG"}, message: "http://127.0.0.1:8085/sign-in 0:0 [DOM] Password field is not contained in a form: (More info: https://goo.gl/9p2vKq) %o"},
+            {level: {name: "INFO"}, message: "http://127.0.0.1:8085/sign-in 0:0 Something useful"}
+          ])
+        })
+      })
+    }))
+
+    expect(await driver.getBrowserLogs()).toEqual(["INFO: Something useful"])
+  })
 })

--- a/spec/webdriver-driver-interact.spec.js
+++ b/spec/webdriver-driver-interact.spec.js
@@ -576,4 +576,30 @@ describe("WebDriverDriver interact", () => {
 
     expect(await driver.getBrowserLogs()).toEqual(["INFO: Something useful"])
   })
+
+  it("does not filter app logs that mention the same phrase", async () => {
+    const driver = new WebDriverDriver({
+      browser: /** @type {any} */ ({
+        driver: undefined,
+        getSelector: (selector) => selector,
+        throwIfHttpServerError: () => {}
+      })
+    })
+
+    driver.setWebDriver(/** @type {any} */ ({
+      manage: () => ({
+        logs: () => ({
+          get: async () => ([
+            {level: {name: "WARNING"}, message: "http://127.0.0.1:8085/sign-in 0:0 Password field is not contained in a form"},
+            {level: {name: "INFO"}, message: "http://127.0.0.1:8085/sign-in 0:0 Something useful"}
+          ])
+        })
+      })
+    }))
+
+    expect(await driver.getBrowserLogs()).toEqual([
+      "WARNING: Password field is not contained in a form",
+      "INFO: Something useful"
+    ])
+  })
 })

--- a/src/drivers/webdriver-driver.js
+++ b/src/drivers/webdriver-driver.js
@@ -91,29 +91,13 @@ function getSendKeysUsesSelectAllAndDelete(...args) {
 }
 
 /**
+ * @param {{level: {name: string}, message: string}} entry
  * @param {string} message
  * @returns {boolean}
  */
-function shouldIgnoreBrowserLogMessage(message) {
-  return /Password field is not contained in a form/i.test(message)
-}
-
-/**
- * React Native Web Pressable controls can render as focusable divs or links,
- * and WebDriver click delivery can become unreliable after Expo Router leaves
- * stale screens in the DOM. Use a DOM click fallback for those controls so
- * onClick/onPress still fires.
- * @param {import("selenium-webdriver").WebElement} element
- * @returns {Promise<boolean>}
- */
-async function shouldUseActionsClickFallback(element) {
-  const tagName = (await element.getTagName()).toLowerCase()
-
-  if (!["a", "div"].includes(tagName)) {
-    return false
-  }
-
-  return await element.getAttribute("tabindex") === "0"
+function shouldIgnoreBrowserLogEntry(entry, message) {
+  return entry.level.name === "DEBUG" &&
+    /^\[DOM\] Password field is not contained in a form:/i.test(message)
 }
 
 /**
@@ -310,7 +294,7 @@ export default class WebDriverDriver {
         message = entry.message
       }
 
-      if (shouldIgnoreBrowserLogMessage(message)) continue
+      if (shouldIgnoreBrowserLogEntry(entry, message)) continue
 
       browserLogs.push(`${entry.level.name}: ${message}`)
     }
@@ -531,11 +515,7 @@ export default class WebDriverDriver {
         if (method === "actions") {
           await this.getWebDriver().actions({async: true}).move({origin: element}).click().perform()
         } else if (method === undefined) {
-          if (await shouldUseActionsClickFallback(element)) {
-            await this.getWebDriver().executeScript("arguments[0].click()", element)
-          } else {
-            await element.click()
-          }
+          await element.click()
         } else {
           throw new Error(`Unknown method: ${method}`)
         }

--- a/src/drivers/webdriver-driver.js
+++ b/src/drivers/webdriver-driver.js
@@ -91,6 +91,32 @@ function getSendKeysUsesSelectAllAndDelete(...args) {
 }
 
 /**
+ * @param {string} message
+ * @returns {boolean}
+ */
+function shouldIgnoreBrowserLogMessage(message) {
+  return /Password field is not contained in a form/i.test(message)
+}
+
+/**
+ * React Native Web Pressable controls can render as focusable divs or links,
+ * and WebDriver click delivery can become unreliable after Expo Router leaves
+ * stale screens in the DOM. Use a DOM click fallback for those controls so
+ * onClick/onPress still fires.
+ * @param {import("selenium-webdriver").WebElement} element
+ * @returns {Promise<boolean>}
+ */
+async function shouldUseActionsClickFallback(element) {
+  const tagName = (await element.getTagName()).toLowerCase()
+
+  if (!["a", "div"].includes(tagName)) {
+    return false
+  }
+
+  return await element.getAttribute("tabindex") === "0"
+}
+
+/**
  * @typedef {object} FindArgs
  * @property {number} [timeout] Override timeout for lookup.
  * @property {boolean | null} [visible] Whether to require elements to be visible (`true`) or hidden (`false`). Use `null` to disable visibility filtering.
@@ -283,6 +309,8 @@ export default class WebDriverDriver {
       } else {
         message = entry.message
       }
+
+      if (shouldIgnoreBrowserLogMessage(message)) continue
 
       browserLogs.push(`${entry.level.name}: ${message}`)
     }
@@ -503,7 +531,11 @@ export default class WebDriverDriver {
         if (method === "actions") {
           await this.getWebDriver().actions({async: true}).move({origin: element}).click().perform()
         } else if (method === undefined) {
-          await element.click()
+          if (await shouldUseActionsClickFallback(element)) {
+            await this.getWebDriver().executeScript("arguments[0].click()", element)
+          } else {
+            await element.click()
+          }
         } else {
           throw new Error(`Unknown method: ${method}`)
         }


### PR DESCRIPTION
## Summary
- filter the Chrome browser log warning about password fields not being inside a form
- keep collected browser logs focused on actionable failures
- cover the filter with a focused webdriver-driver spec
