### PR TITLE
Filter live Chrome password form warnings

### DIFF
--- a/spec/system-test-root-path.spec.js
+++ b/spec/system-test-root-path.spec.js
@@ -36,4 +36,24 @@ describe("SystemTest root path", () => {
     expect(url.searchParams.getAll("systemTestClientWsPort")).toEqual(["7001"])
     expect(url.searchParams.getAll("systemTestScoundrelPort")).toEqual(["7002"])
   })
+  it("ignores the known Chrome password-field DOM warning in live browser errors", () => {
+    spyOn(SystemTest.prototype, "startScoundrel").and.callFake(() => {})
+
+    const systemTest = new SystemTest()
+
+    expect(systemTest.shouldIgnoreError({
+      value: ["[DOM] Password field is not contained in a form: (More info: https://goo.gl/9p2vKq) %o"]
+    })).toBeTrue()
+  })
+
+  it("does not ignore app errors that only mention the same phrase", () => {
+    spyOn(SystemTest.prototype, "startScoundrel").and.callFake(() => {})
+
+    const systemTest = new SystemTest()
+
+    expect(systemTest.shouldIgnoreError({
+      value: ["Password field is not contained in a form"]
+    })).toBeFalse()
+  })
+
 })

--- a/src/system-test.js
+++ b/src/system-test.js
@@ -49,6 +49,14 @@ import Browser from "./browser.js"
  * @property {boolean} [dismiss] Whether to dismiss the notification after it appears.
  */
 
+/**
+ * @param {string} message
+ * @returns {boolean}
+ */
+function shouldIgnoreChromePasswordFieldWarning(message) {
+  return /^\[DOM\] Password field is not contained in a form:/i.test(message)
+}
+
 /** @type {Record<string, any>} */
 const globalAny = globalThis
 
@@ -121,6 +129,7 @@ export default class SystemTest extends Browser {
     if (typeof message === "string") {
       if (message.includes("Minified React error #418")) return true
       if (message.includes("Minified React error #419")) return true
+      if (shouldIgnoreChromePasswordFieldWarning(message)) return true
     }
 
     if (this._errorFilter && this._errorFilter(data) === false) {


### PR DESCRIPTION
## Summary
- ignore the known Chrome `[DOM] Password field is not contained in a form:` warning in the live `console.error` stream as well as browser-log collection
- keep the filter narrow so normal app errors that only mention the same phrase still surface
- add unit coverage for the live `SystemTest.shouldIgnoreError()` path

## Validation
- `npx jasmine spec/system-test-root-path.spec.js`
- `npm run lint`
- `npm run typecheck`
