### PR TITLE
Filter URL-prefixed Chrome password form warnings

### DIFF
--- a/spec/system-test-root-path.spec.js
+++ b/spec/system-test-root-path.spec.js
@@ -46,6 +46,17 @@ describe("SystemTest root path", () => {
     })).toBeTrue()
   })
 
+
+  it("ignores the known Chrome password-field DOM warning when Chrome prefixes the URL", () => {
+    spyOn(SystemTest.prototype, "startScoundrel").and.callFake(() => {})
+
+    const systemTest = new SystemTest()
+
+    expect(systemTest.shouldIgnoreError({
+      value: ["http://127.0.0.1:8085/ - [DOM] Password field is not contained in a form: (More info: https://goo.gl/9p2vKq) %o"]
+    })).toBeTrue()
+  })
+
   it("does not ignore app errors that only mention the same phrase", () => {
     spyOn(SystemTest.prototype, "startScoundrel").and.callFake(() => {})
 

--- a/spec/webdriver-driver-interact.spec.js
+++ b/spec/webdriver-driver-interact.spec.js
@@ -577,6 +577,29 @@ describe("WebDriverDriver interact", () => {
     expect(await driver.getBrowserLogs()).toEqual(["INFO: Something useful"])
   })
 
+  it("filters the known Chrome password-not-in-form warning when the browser prefixes the URL", async () => {
+    const driver = new WebDriverDriver({
+      browser: /** @type {any} */ ({
+        driver: undefined,
+        getSelector: (selector) => selector,
+        throwIfHttpServerError: () => {}
+      })
+    })
+
+    driver.setWebDriver(/** @type {any} */ ({
+      manage: () => ({
+        logs: () => ({
+          get: async () => ([
+            {level: {name: "DEBUG"}, message: "http://127.0.0.1:8085/ - [DOM] Password field is not contained in a form: (More info: https://goo.gl/9p2vKq) %o"},
+            {level: {name: "INFO"}, message: "http://127.0.0.1:8085/ 0:0 Something useful"}
+          ])
+        })
+      })
+    }))
+
+    expect(await driver.getBrowserLogs()).toEqual(["INFO: Something useful"])
+  })
+
   it("does not filter app logs that mention the same phrase", async () => {
     const driver = new WebDriverDriver({
       browser: /** @type {any} */ ({

--- a/src/drivers/webdriver-driver.js
+++ b/src/drivers/webdriver-driver.js
@@ -97,7 +97,7 @@ function getSendKeysUsesSelectAllAndDelete(...args) {
  */
 function shouldIgnoreBrowserLogEntry(entry, message) {
   return entry.level.name === "DEBUG" &&
-    /^\[DOM\] Password field is not contained in a form:/i.test(message)
+    /(?:^|\s-\s)\[DOM\] Password field is not contained in a form:/i.test(message)
 }
 
 /**

--- a/src/system-test.js
+++ b/src/system-test.js
@@ -54,7 +54,7 @@ import Browser from "./browser.js"
  * @returns {boolean}
  */
 function shouldIgnoreChromePasswordFieldWarning(message) {
-  return /^\[DOM\] Password field is not contained in a form:/i.test(message)
+  return /(?:^|\s-\s)\[DOM\] Password field is not contained in a form:/i.test(message)
 }
 
 /** @type {Record<string, any>} */


### PR DESCRIPTION
## Summary
- expand the Chrome password-form warning filter to handle messages prefixed with the page URL
- apply the same matching logic to live browser errors and webdriver browser logs
- add regression coverage for the URL-prefixed warning shape seen in Peakflow

## Testing
- npx jasmine spec/system-test-root-path.spec.js spec/webdriver-driver-interact.spec.js
- npm run lint
- npm run typecheck