### PR TITLE
Reset Stack history on dismissTo to unmount stale screens

### DIFF
--- a/src/use-system-test-expo.js
+++ b/src/use-system-test-expo.js
@@ -1,4 +1,4 @@
-import {useNavigationContainerRef, useRouter} from "expo-router"
+import {useRouter} from "expo-router"
 import useSystemTest from "./use-system-test.js"
 
 /**
@@ -14,7 +14,6 @@ import useSystemTest from "./use-system-test.js"
  */
 export default function useSystemTestExpo({browserHelper, enabled, host, onFirstInitialize, onInitialize, onTeardown, ...restArgs} = {browserHelper: undefined, enabled: undefined, host: undefined, onFirstInitialize: undefined, onInitialize: undefined, onTeardown: undefined}) {
   const router = useRouter()
-  const navigationRef = useNavigationContainerRef()
   const restArgsKeys = Object.keys(restArgs)
 
   if (restArgsKeys.length > 0) {
@@ -32,22 +31,15 @@ export default function useSystemTestExpo({browserHelper, enabled, host, onFirst
         console.error(`Failed to dismiss to path "${path}": ${error instanceof Error ? error.message : error}`)
       }
 
-      // Flush the Stack history so previously-visited screens unmount instead
-      // of accumulating in DOM with display:none. Without this, react-native-web's
-      // global PressResponder gets confused by stale Pressables that share the
-      // same testID as the visible one and Selenium clicks fail to fire onPress.
+      // Pop every other screen off the Stack so previously-visited routes
+      // unmount instead of accumulating in DOM with display:none. Without this,
+      // react-native-web's global PressResponder gets confused by stale
+      // Pressables that share the same testID as the visible one and Selenium
+      // clicks fail to fire onPress.
       try {
-        const state = navigationRef.getRootState?.()
-        const currentRoute = state?.routes?.[state.routes.length - 1]
-
-        if (currentRoute) {
-          navigationRef.reset({
-            index: 0,
-            routes: [{name: currentRoute.name, params: currentRoute.params, path: currentRoute.path}]
-          })
-        }
+        router.dismissAll()
       } catch (error) {
-        console.error(`Failed to reset navigation history: ${error instanceof Error ? error.message : error}`)
+        console.error(`Failed to dismiss all stack screens: ${error instanceof Error ? error.message : error}`)
       }
     },
     onFirstInitialize,

--- a/src/use-system-test-expo.js
+++ b/src/use-system-test-expo.js
@@ -1,4 +1,4 @@
-import {useRouter} from "expo-router"
+import {useNavigationContainerRef, useRouter} from "expo-router"
 import useSystemTest from "./use-system-test.js"
 
 /**
@@ -14,6 +14,7 @@ import useSystemTest from "./use-system-test.js"
  */
 export default function useSystemTestExpo({browserHelper, enabled, host, onFirstInitialize, onInitialize, onTeardown, ...restArgs} = {browserHelper: undefined, enabled: undefined, host: undefined, onFirstInitialize: undefined, onInitialize: undefined, onTeardown: undefined}) {
   const router = useRouter()
+  const navigationRef = useNavigationContainerRef()
   const restArgsKeys = Object.keys(restArgs)
 
   if (restArgsKeys.length > 0) {
@@ -29,6 +30,24 @@ export default function useSystemTestExpo({browserHelper, enabled, host, onFirst
         router.dismissTo(path)
       } catch (error) {
         console.error(`Failed to dismiss to path "${path}": ${error instanceof Error ? error.message : error}`)
+      }
+
+      // Flush the Stack history so previously-visited screens unmount instead
+      // of accumulating in DOM with display:none. Without this, react-native-web's
+      // global PressResponder gets confused by stale Pressables that share the
+      // same testID as the visible one and Selenium clicks fail to fire onPress.
+      try {
+        const state = navigationRef.getRootState?.()
+        const currentRoute = state?.routes?.[state.routes.length - 1]
+
+        if (currentRoute) {
+          navigationRef.reset({
+            index: 0,
+            routes: [{name: currentRoute.name, params: currentRoute.params, path: currentRoute.path}]
+          })
+        }
+      } catch (error) {
+        console.error(`Failed to reset navigation history: ${error instanceof Error ? error.message : error}`)
       }
     },
     onFirstInitialize,


### PR DESCRIPTION
## Summary
- After `router.dismissTo(path)`, also call `navigationRef.reset({...})` so React Navigation's Stack flushes everything except the current route.
- Without this, Expo Router apps using `<Stack>` accumulate every visited screen in the DOM (`display:none`) across the test run.
- The accumulated stale Pressables share `testID`s with the visible ones; React Native Web's global `PressResponder` then fails to grant press to the visible element and Selenium clicks never fire `onPress`.

## Context

In `ticket-app`'s stagemap-app suite, tests 08/09/21 were failing with "onSeatSelect never fired after click" / contingent-reserve never opening the picker. CI browser logs confirmed:
- Tests early in the run (small DOM): all Pressable clicks fire → tests pass.
- Tests late in the run (stale-screen count > ~20): even the sign-in submit Pressable doesn't fire → fallback sign-in path triggers → seat clicks also don't fire.

After this change, `dismissTo` (which `system-test.js` calls before every test) collapses the Stack history so the DOM stays small.

## Test plan
- [x] `npm run lint` clean
- [x] `npm test` passes (87 specs, 0 failures)
- [ ] Verify on Peakflow CI for ticket-app — bump the dependency once this lands and a release is cut.