### PR TITLE
Add {method: "js"} click path

### DIFF
--- a/changelog.d/20260415-webdriver-click-js-method.md
+++ b/changelog.d/20260415-webdriver-click-js-method.md
@@ -1,0 +1,1 @@
+Support `{method: "js"}` on `click`/`interact` so callers can dispatch `element.click()` via `executeScript` inside the page's JS context. Useful when the default WebDriver click is dropped by a framework responder that refuses synthetic pointer events.

--- a/spec/system-test-interact.spec.js
+++ b/spec/system-test-interact.spec.js
@@ -95,6 +95,58 @@ describe("SystemTest interact", () => {
     })
   })
 
+  itIfWeb("dispatches element.click() via executeScript when method:'js' is set", async () => {
+    await SystemTest.run(async (runningSystemTest) => {
+      const originalBaseSelector = runningSystemTest.getBaseSelector()
+
+      try {
+        runningSystemTest.setBaseSelector("#does-not-exist")
+
+        await runningSystemTest.getDriver().executeScript(`
+          const elementId = "system-test-interact-js-target"
+          let element = document.getElementById(elementId)
+
+          if (element) {
+            element.remove()
+          }
+
+          element = document.createElement("button")
+          element.id = elementId
+          element.setAttribute("data-testid", "systemTestJsClickTarget")
+          element.style.position = "fixed"
+          element.style.top = "12px"
+          element.style.left = "12px"
+          element.style.zIndex = "9999"
+          element.textContent = "JS click target"
+          element.addEventListener("click", () => {
+            element.setAttribute("data-clicked", "true")
+          })
+          document.body.appendChild(element)
+          return true
+        `)
+
+        await runningSystemTest.interact({selector: "[data-testid='systemTestJsClickTarget']", method: "js", useBaseSelector: false}, "click")
+
+        const wasClicked = await runningSystemTest.getDriver().executeScript(`
+          const element = document.querySelector("[data-testid='systemTestJsClickTarget']")
+          return element?.getAttribute("data-clicked") === "true"
+        `)
+
+        expect(wasClicked).toBeTrue()
+      } finally {
+        if (originalBaseSelector) {
+          runningSystemTest.setBaseSelector(originalBaseSelector)
+        }
+
+        await runningSystemTest.getDriver().executeScript(`
+          const element = document.getElementById("system-test-interact-js-target")
+          if (element) element.remove()
+          return true
+        `)
+      }
+    })
+  })
+
   it("clears and sends replacement keys through retryable interactions", async () => {
     const systemTest = systemTestHelper.getSystemTest()
     const interactSpy = spyOn(systemTest, "interact").and.resolveTo(undefined)

--- a/spec/system-test-interact.spec.js
+++ b/spec/system-test-interact.spec.js
@@ -102,6 +102,12 @@ describe("SystemTest interact", () => {
       try {
         runningSystemTest.setBaseSelector("#does-not-exist")
 
+        // Record isTrusted on the click event. The WebDriver default click
+        // path fires a trusted user-gesture event (isTrusted=true). An
+        // executeScript("arguments[0].click()") call fires a programmatic
+        // click, which is always isTrusted=false. This is how we actually
+        // prove method:"js" took the executeScript path instead of the
+        // normal WebDriver click.
         await runningSystemTest.getDriver().executeScript(`
           const elementId = "system-test-interact-js-target"
           let element = document.getElementById(elementId)
@@ -118,8 +124,9 @@ describe("SystemTest interact", () => {
           element.style.left = "12px"
           element.style.zIndex = "9999"
           element.textContent = "JS click target"
-          element.addEventListener("click", () => {
+          element.addEventListener("click", (event) => {
             element.setAttribute("data-clicked", "true")
+            element.setAttribute("data-trusted", String(event.isTrusted))
           })
           document.body.appendChild(element)
           return true
@@ -127,12 +134,15 @@ describe("SystemTest interact", () => {
 
         await runningSystemTest.interact({selector: "[data-testid='systemTestJsClickTarget']", method: "js", useBaseSelector: false}, "click")
 
-        const wasClicked = await runningSystemTest.getDriver().executeScript(`
+        const result = await runningSystemTest.getDriver().executeScript(`
           const element = document.querySelector("[data-testid='systemTestJsClickTarget']")
-          return element?.getAttribute("data-clicked") === "true"
+          return {
+            clicked: element?.getAttribute("data-clicked"),
+            trusted: element?.getAttribute("data-trusted")
+          }
         `)
 
-        expect(wasClicked).toBeTrue()
+        expect(result).toEqual({clicked: "true", trusted: "false"})
       } finally {
         if (originalBaseSelector) {
           runningSystemTest.setBaseSelector(originalBaseSelector)
@@ -140,6 +150,66 @@ describe("SystemTest interact", () => {
 
         await runningSystemTest.getDriver().executeScript(`
           const element = document.getElementById("system-test-interact-js-target")
+          if (element) element.remove()
+          return true
+        `)
+      }
+    })
+  })
+
+  itIfWeb("dispatches a trusted click event by default (not via executeScript)", async () => {
+    await SystemTest.run(async (runningSystemTest) => {
+      const originalBaseSelector = runningSystemTest.getBaseSelector()
+
+      try {
+        runningSystemTest.setBaseSelector("#does-not-exist")
+
+        // Paired companion to the method:"js" spec above: asserts the
+        // default click path fires a trusted (isTrusted=true) event. This
+        // is what distinguishes the default path from method:"js". If both
+        // this and the js spec pass, the js path is demonstrably different.
+        await runningSystemTest.getDriver().executeScript(`
+          const elementId = "system-test-interact-default-target"
+          let element = document.getElementById(elementId)
+
+          if (element) {
+            element.remove()
+          }
+
+          element = document.createElement("button")
+          element.id = elementId
+          element.setAttribute("data-testid", "systemTestDefaultClickTarget")
+          element.style.position = "fixed"
+          element.style.top = "12px"
+          element.style.left = "12px"
+          element.style.zIndex = "9999"
+          element.textContent = "Default click target"
+          element.addEventListener("click", (event) => {
+            element.setAttribute("data-clicked", "true")
+            element.setAttribute("data-trusted", String(event.isTrusted))
+          })
+          document.body.appendChild(element)
+          return true
+        `)
+
+        await runningSystemTest.interact({selector: "[data-testid='systemTestDefaultClickTarget']", useBaseSelector: false}, "click")
+
+        const result = await runningSystemTest.getDriver().executeScript(`
+          const element = document.querySelector("[data-testid='systemTestDefaultClickTarget']")
+          return {
+            clicked: element?.getAttribute("data-clicked"),
+            trusted: element?.getAttribute("data-trusted")
+          }
+        `)
+
+        expect(result).toEqual({clicked: "true", trusted: "true"})
+      } finally {
+        if (originalBaseSelector) {
+          runningSystemTest.setBaseSelector(originalBaseSelector)
+        }
+
+        await runningSystemTest.getDriver().executeScript(`
+          const element = document.getElementById("system-test-interact-default-target")
           if (element) element.remove()
           return true
         `)

--- a/spec/webdriver-driver-interact.spec.js
+++ b/spec/webdriver-driver-interact.spec.js
@@ -401,6 +401,32 @@ describe("WebDriverDriver interact", () => {
     expect(actions.perform).toHaveBeenCalled()
   })
 
+  it("dispatches element.click() via executeScript when method is 'js'", async () => {
+    const element = {
+      getId: async () => "webdriver-element-id"
+    }
+    const executeScriptSpy = jasmine.createSpy("executeScript").and.resolveTo(undefined)
+    const driver = new WebDriverDriver({
+      browser: /** @type {any} */ ({
+        driver: undefined,
+        getSelector: (selector) => selector,
+        throwIfHttpServerError: () => {}
+      })
+    })
+    const scrollSpy = jasmine.createSpy("scrollElementIntoView").and.resolveTo(undefined)
+
+    driver._findElement = async () => /** @type {any} */ (element)
+    driver.scrollElementIntoView = /** @type {any} */ (scrollSpy)
+    driver.setWebDriver(/** @type {any} */ ({
+      executeScript: executeScriptSpy
+    }))
+
+    await driver.click(element, {method: "js", scrollTo: true})
+
+    expect(scrollSpy).toHaveBeenCalledWith(element)
+    expect(executeScriptSpy).toHaveBeenCalledWith("arguments[0].click()", element)
+  })
+
   it("calls plain element click handlers directly for non-webdriver elements", async () => {
     const element = {
       click: jasmine.createSpy("elementClick").and.resolveTo("clicked")

--- a/spec/webdriver-driver-interact.spec.js
+++ b/spec/webdriver-driver-interact.spec.js
@@ -184,6 +184,29 @@ describe("WebDriverDriver interact", () => {
     expect(element.click).not.toHaveBeenCalled()
   })
 
+  it("passes the js click method through interact click calls for webdriver elements", async () => {
+    const element = {
+      getId: async () => "webdriver-element-id",
+      click: jasmine.createSpy("elementClick")
+    }
+    const driver = new WebDriverDriver({
+      browser: /** @type {any} */ ({
+        driver: undefined,
+        getSelector: (selector) => selector,
+        throwIfHttpServerError: () => {}
+      })
+    })
+    const clickSpy = jasmine.createSpy("click").and.resolveTo(undefined)
+
+    driver._findElement = async () => /** @type {any} */ (element)
+    driver.click = /** @type {any} */ (clickSpy)
+
+    await driver.interact({selector: "[data-testid='project-environment-agent-submit']", method: "js", scrollTo: true}, "click")
+
+    expect(clickSpy).toHaveBeenCalledWith(element, {method: "js", scrollTo: true})
+    expect(element.click).not.toHaveBeenCalled()
+  })
+
   it("strips interact-only selector args before element lookup for click interactions", async () => {
     const element = {
       getId: async () => "webdriver-element-id",

--- a/src/drivers/webdriver-driver.js
+++ b/src/drivers/webdriver-driver.js
@@ -104,7 +104,7 @@ function shouldIgnoreBrowserLogEntry(entry, message) {
  * @typedef {object} FindArgs
  * @property {number} [timeout] Override timeout for lookup.
  * @property {boolean | null} [visible] Whether to require elements to be visible (`true`) or hidden (`false`). Use `null` to disable visibility filtering.
- * @property {"actions"} [method] Use the Selenium Actions API instead of a normal element click.
+ * @property {"actions" | "js"} [method] Override the click path. `"actions"` uses the Selenium Actions API (real pointer move + click); `"js"` dispatches `element.click()` via `executeScript` inside the page's JS context (skips WebDriver's pointer synthesis entirely — useful when the default click is dropped by a framework responder that refuses synthetic WebDriver pointer events).
  * @property {boolean} [scrollTo] Whether to scroll found elements into view before returning them.
  * @property {boolean} [useBaseSelector] Whether to scope by the base selector.
  */
@@ -514,6 +514,8 @@ export default class WebDriverDriver {
 
         if (method === "actions") {
           await this.getWebDriver().actions({async: true}).move({origin: element}).click().perform()
+        } else if (method === "js") {
+          await this.getWebDriver().executeScript("arguments[0].click()", element)
         } else if (method === undefined) {
           await element.click()
         } else {

--- a/src/system-test.js
+++ b/src/system-test.js
@@ -33,7 +33,7 @@ import Browser from "./browser.js"
  * @typedef {object} FindArgs
  * @property {number} [timeout] Override timeout for lookup.
  * @property {boolean | null} [visible] Whether to require elements to be visible (`true`) or hidden (`false`). Use `null` to disable visibility filtering.
- * @property {"actions"} [method] Use the Selenium Actions API instead of a normal element click.
+ * @property {"actions" | "js"} [method] Override the click path. `"actions"` uses the Selenium Actions API (real pointer move + click); `"js"` dispatches `element.click()` via `executeScript` inside the page's JS context (skips WebDriver's pointer synthesis entirely — useful when the default click is dropped by a framework responder that refuses synthetic WebDriver pointer events).
  * @property {boolean} [scrollTo] Whether to scroll found elements into view before returning them.
  * @property {boolean} [useBaseSelector] Whether to scope by the base selector.
  */


### PR DESCRIPTION
## Summary
- New `{method: "js"}` option on `click`/`interact` that dispatches `element.click()` via `executeScript`, inside the page's JS context.
- Skips WebDriver's synthetic-pointer click path. Useful when a framework responder (for example react-native-web's PressResponder on small Pressables in freshly reinitialized Chrome sessions) deterministically drops the default WebDriver click.
- Default path is unchanged; the `js` option is strictly opt-in per call site.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npx jasmine spec/webdriver-driver-interact.spec.js` (24/24 pass, new spec covers the JS click path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)