### PR TITLE
Quit the WebDriver on process exit so Chrome isn't orphaned

### DIFF
--- a/spec/webdriver-driver-lifecycle.spec.js
+++ b/spec/webdriver-driver-lifecycle.spec.js
@@ -1,0 +1,78 @@
+// @ts-check
+
+import WebDriverDriver from "../src/drivers/webdriver-driver.js"
+
+/** @returns {{driver: WebDriverDriver, quitCalls: () => number}} */
+function newDriver() {
+  const driver = new WebDriverDriver({
+    browser: /** @type {any} */ ({
+      driver: undefined,
+      throwIfHttpServerError: () => {}
+    })
+  })
+  let quitCount = 0
+  driver.setWebDriver(/** @type {any} */ ({
+    quit: async () => {
+      quitCount += 1
+    }
+  }))
+  return {driver, quitCalls: () => quitCount}
+}
+
+describe("WebDriverDriver lifecycle", () => {
+  it("installs SIGINT/SIGTERM/beforeExit listeners when installExitHandlers() is called", () => {
+    const before = {
+      sigint: process.listenerCount("SIGINT"),
+      sigterm: process.listenerCount("SIGTERM"),
+      beforeExit: process.listenerCount("beforeExit")
+    }
+    const {driver} = newDriver()
+    driver.installExitHandlers()
+
+    expect(process.listenerCount("SIGINT")).toBe(before.sigint + 1)
+    expect(process.listenerCount("SIGTERM")).toBe(before.sigterm + 1)
+    expect(process.listenerCount("beforeExit")).toBe(before.beforeExit + 1)
+
+    driver._removeExitHandlers()
+  })
+
+  it("removes the exit listeners when stop() is called so repeated setup/teardown does not leak", async () => {
+    const before = {
+      sigint: process.listenerCount("SIGINT"),
+      sigterm: process.listenerCount("SIGTERM"),
+      beforeExit: process.listenerCount("beforeExit")
+    }
+    const {driver, quitCalls} = newDriver()
+    driver.installExitHandlers()
+
+    await driver.stop()
+
+    expect(process.listenerCount("SIGINT")).toBe(before.sigint)
+    expect(process.listenerCount("SIGTERM")).toBe(before.sigterm)
+    expect(process.listenerCount("beforeExit")).toBe(before.beforeExit)
+    expect(quitCalls()).toBe(1)
+  })
+
+  it("quits the WebDriver when the process idles (beforeExit path)", async () => {
+    const {driver, quitCalls} = newDriver()
+    driver.installExitHandlers()
+
+    await driver._onExitSignal("beforeExit")
+
+    expect(quitCalls()).toBe(1)
+    expect(driver.webDriver).toBeUndefined()
+  })
+
+  it("does not install handlers when setWebDriver is used directly (unit-test path)", () => {
+    const before = {
+      sigint: process.listenerCount("SIGINT"),
+      sigterm: process.listenerCount("SIGTERM"),
+      beforeExit: process.listenerCount("beforeExit")
+    }
+    newDriver()
+
+    expect(process.listenerCount("SIGINT")).toBe(before.sigint)
+    expect(process.listenerCount("SIGTERM")).toBe(before.sigterm)
+    expect(process.listenerCount("beforeExit")).toBe(before.beforeExit)
+  })
+})

--- a/src/drivers/appium-driver.js
+++ b/src/drivers/appium-driver.js
@@ -124,6 +124,7 @@ export default class AppiumDriver extends WebDriverDriver {
       const webDriver = await builder.build()
 
       this.setWebDriver(webDriver)
+      this.installExitHandlers()
     } catch (error) {
       await this.cleanupChromeUserDataDir()
       throw error

--- a/src/drivers/selenium-driver.js
+++ b/src/drivers/selenium-driver.js
@@ -47,5 +47,6 @@ export default class SeleniumDriver extends WebDriverDriver {
     const webDriver = await builder.build()
 
     this.setWebDriver(webDriver)
+    this.installExitHandlers()
   }
 }

--- a/src/drivers/webdriver-driver.js
+++ b/src/drivers/webdriver-driver.js
@@ -228,9 +228,12 @@ export default class WebDriverDriver {
       // Best-effort — the process is going down anyway, and we'd rather
       // orphan a browser than throw from a signal handler.
     }
-    if (signal === "SIGINT" || signal === "SIGTERM") {
-      process.exit(0)
-    }
+    // Preserve the conventional signal-exit status (128 + signal number)
+    // so CI / wrapper scripts can still tell interrupted runs apart
+    // from a clean pass. Plain `process.exit(0)` would misreport a
+    // cancelled run as successful.
+    if (signal === "SIGINT") process.exit(130)
+    if (signal === "SIGTERM") process.exit(143)
   }
 
   /**

--- a/src/drivers/webdriver-driver.js
+++ b/src/drivers/webdriver-driver.js
@@ -135,6 +135,13 @@ export default class WebDriverDriver {
     this.webDriver = undefined
     this._driverTimeouts = 5000
     this._timeouts = 5000
+    /**
+     * Process-exit handlers installed while a WebDriver session is alive.
+     * Retained so `stop()` can deregister them before removing the
+     * WebDriver reference.
+     * @type {{sigint: () => void, sigterm: () => void, beforeExit: () => void} | null}
+     */
+    this._exitHandlers = null
   }
 
   /**
@@ -177,6 +184,56 @@ export default class WebDriverDriver {
   }
 
   /**
+   * Installs process-level handlers that terminate the WebDriver session
+   * if the Node process exits without an explicit `stop()` call. Without
+   * this, the chromedriver-spawned Chrome is orphaned to init (PPID=1)
+   * when the test runner exits — each `npx velocious test` run that
+   * skips explicit cleanup leaves a Chrome plus thousands of
+   * `/tmp/org.chromium.Chromium.scoped_dir.*` behind. Driver subclass
+   * `start()` implementations must call this after setting the
+   * WebDriver on a fresh session; tests that stub `setWebDriver`
+   * directly deliberately bypass it.
+   * @returns {void}
+   */
+  installExitHandlers() {
+    if (this._exitHandlers) return
+    const sigint = () => { void this._onExitSignal("SIGINT") }
+    const sigterm = () => { void this._onExitSignal("SIGTERM") }
+    const beforeExit = () => { void this._onExitSignal("beforeExit") }
+    process.once("SIGINT", sigint)
+    process.once("SIGTERM", sigterm)
+    process.once("beforeExit", beforeExit)
+    this._exitHandlers = {sigint, sigterm, beforeExit}
+  }
+
+  /** @returns {void} */
+  _removeExitHandlers() {
+    const handlers = this._exitHandlers
+    if (!handlers) return
+    this._exitHandlers = null
+    process.off("SIGINT", handlers.sigint)
+    process.off("SIGTERM", handlers.sigterm)
+    process.off("beforeExit", handlers.beforeExit)
+  }
+
+  /**
+   * @param {"SIGINT" | "SIGTERM" | "beforeExit"} signal
+   * @returns {Promise<void>}
+   */
+  async _onExitSignal(signal) {
+    this._removeExitHandlers()
+    try {
+      await this.stop()
+    } catch {
+      // Best-effort — the process is going down anyway, and we'd rather
+      // orphan a browser than throw from a signal handler.
+    }
+    if (signal === "SIGINT" || signal === "SIGTERM") {
+      process.exit(0)
+    }
+  }
+
+  /**
    * @returns {Promise<void>}
    */
   async start() {
@@ -187,6 +244,7 @@ export default class WebDriverDriver {
    * @returns {Promise<void>}
    */
   async stop() {
+    this._removeExitHandlers()
     if (this.webDriver) {
       await timeout({timeout: this.getTimeouts(), errorMessage: "timeout while quitting WebDriver"}, async () => await /** @type {NonNullable<typeof this.webDriver>} */ (this.webDriver).quit())
     }


### PR DESCRIPTION
## Summary

`SystemTest.run()` reuses a process-wide singleton WebDriver across every spec and never calls `SystemTest.stop()` when the Node process exits. That leaves the chromedriver-spawned Chrome orphaned to init (`PPID=1`) when the test runner exits — each `npx velocious test` run that skips explicit cleanup leaves a Chrome plus a `/tmp/org.chromium.Chromium.scoped_dir.*` behind. A downstream repo just reported **three runaway Chrome instances** and **4,577 stale scoped-dirs** accumulated over weeks on one developer's machine.

Fix by adding process-level `SIGINT` / `SIGTERM` / `beforeExit` handlers on `WebDriverDriver` that call `stop()` (which already invokes `driver.quit()`) when the process is going down without an explicit tear-down. Handlers are installed from each real driver's `start()` (`SeleniumDriver`, `AppiumDriver`) after the WebDriver is built, and are removed when `stop()` runs normally so repeated setup/teardown doesn't leak listeners. Unit tests that stub `setWebDriver` directly bypass the install — keeps the lifecycle scoped to the real WebDriver path.

## Test plan
- [x] `npm run typecheck` clean.
- [x] `npm run lint` clean.
- [x] Full `npx jasmine` suite: **95 specs, 0 failures** (up from 92 before this PR adds the 3 new lifecycle specs).
- [x] New `spec/webdriver-driver-lifecycle.spec.js` covers: listener install from `installExitHandlers()`, listener removal on `stop()`, WebDriver quit on `beforeExit`, and that direct-`setWebDriver` unit-test paths do not install handlers.