### PR TITLE
Allow scroll helpers to target offscreen elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Reinitialize `SystemTest.run(...)` browser state after failed callbacks or teardown by default.
 - Let scroll helpers find rendered targets before they are visible in the viewport.
 - Prevent system test shutdown timeouts by forcing HTTP server connections closed and shutting down the browser before the HTTP server.
 - Convert patch release script to Node and add `release:patch` npm script.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Let scroll helpers find rendered targets before they are visible in the viewport.
 - Prevent system test shutdown timeouts by forcing HTTP server connections closed and shutting down the browser before the HTTP server.
 - Convert patch release script to Node and add `release:patch` npm script.
 - Run release patch commands with direct TTY handling for npm 2FA prompts.

--- a/README.md
+++ b/README.md
@@ -449,6 +449,14 @@ await systemTest.reinitialize()
 
 This tears down the browser, servers, and sockets, then starts them again so subsequent steps run against a fresh app instance.
 
+`SystemTest.run(...)` does this automatically after a failed callback or teardown by default. Disable it only for tests that intentionally inspect the broken session after failure:
+
+```js
+await SystemTest.run({reinitializeAfterFailure: false}, async (systemTest) => {
+  await systemTest.findByTestID("brokenState")
+})
+```
+
 ## Dummy Expo app
 
 A ready-to-run Expo Router dummy app that uses `system-testing` lives in `spec/dummy`.

--- a/spec/system-test-run.spec.js
+++ b/spec/system-test-run.spec.js
@@ -1,0 +1,64 @@
+// @ts-check
+
+import SystemTest from "../src/system-test.js"
+
+/**
+ * @returns {{communicator: {sendCommand: jasmine.Spy}, systemTest: Record<string, any>}}
+ */
+function createSystemTestRunDouble() {
+  const communicator = {
+    sendCommand: jasmine.createSpy("sendCommand").and.resolveTo(undefined),
+    ws: {readyState: 1}
+  }
+
+  return {
+    communicator,
+    systemTest: {
+      debugLog: jasmine.createSpy("debugLog"),
+      deleteAllCookies: jasmine.createSpy("deleteAllCookies").and.resolveTo(undefined),
+      dismissTo: jasmine.createSpy("dismissTo").and.resolveTo(undefined),
+      findByTestID: jasmine.createSpy("findByTestID").and.resolveTo(undefined),
+      getCommunicator: jasmine.createSpy("getCommunicator").and.returnValue(communicator),
+      getRootPath: jasmine.createSpy("getRootPath").and.returnValue("/blank?systemTest=true"),
+      reinitialize: jasmine.createSpy("reinitialize").and.resolveTo(undefined),
+      takeScreenshot: jasmine.createSpy("takeScreenshot").and.resolveTo(undefined),
+      waitForClientWebSocket: jasmine.createSpy("waitForClientWebSocket").and.resolveTo(undefined),
+      ws: {readyState: 1}
+    }
+  }
+}
+
+describe("SystemTest.run", () => {
+  it("reinitializes the system test after a failed callback by default", async () => {
+    const {communicator, systemTest} = createSystemTestRunDouble()
+    spyOn(SystemTest, "current").and.returnValue(/** @type {SystemTest} */ (systemTest))
+
+    await expectAsync(SystemTest.run(async () => {
+      throw new Error("boom")
+    })).toBeRejectedWithError("boom")
+
+    expect(systemTest.takeScreenshot).toHaveBeenCalled()
+    expect(communicator.sendCommand).toHaveBeenCalledWith({type: "teardown"})
+    expect(systemTest.reinitialize).toHaveBeenCalledTimes(1)
+  })
+
+  it("can skip reinitializing the system test after a failed callback", async () => {
+    const {systemTest} = createSystemTestRunDouble()
+    spyOn(SystemTest, "current").and.returnValue(/** @type {SystemTest} */ (systemTest))
+
+    await expectAsync(SystemTest.run({reinitializeAfterFailure: false}, async () => {
+      throw new Error("boom")
+    })).toBeRejectedWithError("boom")
+
+    expect(systemTest.reinitialize).not.toHaveBeenCalled()
+  })
+
+  it("does not reinitialize the system test after a successful callback", async () => {
+    const {systemTest} = createSystemTestRunDouble()
+    spyOn(SystemTest, "current").and.returnValue(/** @type {SystemTest} */ (systemTest))
+
+    await SystemTest.run(async () => {})
+
+    expect(systemTest.reinitialize).not.toHaveBeenCalled()
+  })
+})

--- a/spec/webdriver-driver-interact.spec.js
+++ b/spec/webdriver-driver-interact.spec.js
@@ -591,16 +591,48 @@ describe("WebDriverDriver interact", () => {
       executeScript: executeScriptSpy
     }
 
-    driver._findElement = async () => /** @type {any} */ (element)
+    const findElementSpy = jasmine.createSpy("_findElement").and.resolveTo(element)
+
+    driver._findElement = /** @type {any} */ (findElementSpy)
     driver.setWebDriver(/** @type {any} */ (webDriver))
     driver.isElementInViewport = /** @type {any} */ (jasmine.createSpy("isElementInViewport").and.resolveTo(true))
 
     await driver.scrollIntoView({selector: "[data-testid='project-environment-agent-submit']"})
 
+    expect(findElementSpy).toHaveBeenCalledWith({selector: "[data-testid='project-environment-agent-submit']", visible: null}, undefined)
     expect(webDriver.actions).toHaveBeenCalledWith({async: true})
     expect(moveSpy).toHaveBeenCalledWith({origin: element})
     expect(performSpy).toHaveBeenCalled()
     expect(executeScriptSpy).not.toHaveBeenCalled()
+  })
+
+  it("finds test ID scroll targets without requiring pre-scroll visibility", async () => {
+    const element = {
+      getId: async () => "webdriver-element-id"
+    }
+    const performSpy = jasmine.createSpy("perform").and.resolveTo(undefined)
+    const moveSpy = jasmine.createSpy("move").and.returnValue({perform: performSpy})
+    const driver = new WebDriverDriver({
+      browser: /** @type {any} */ ({
+        driver: undefined,
+        getSelector: (selector) => selector,
+        throwIfHttpServerError: () => {}
+      })
+    })
+    const webDriver = {
+      actions: jasmine.createSpy("actions").and.returnValue({move: moveSpy})
+    }
+    const findByTestIDSpy = jasmine.createSpy("findByTestID").and.resolveTo(element)
+
+    driver.findByTestID = /** @type {any} */ (findByTestIDSpy)
+    driver.setWebDriver(/** @type {any} */ (webDriver))
+
+    await driver.scrollTestIdIntoView("project-environment-agent-submit")
+
+    expect(findByTestIDSpy).toHaveBeenCalledWith("project-environment-agent-submit", {visible: null})
+    expect(webDriver.actions).toHaveBeenCalledWith({async: true})
+    expect(moveSpy).toHaveBeenCalledWith({origin: element})
+    expect(performSpy).toHaveBeenCalled()
   })
 
   it("filters the known Chrome password-not-in-form warning from browser logs", async () => {

--- a/spec/webdriver-driver-interact.spec.js
+++ b/spec/webdriver-driver-interact.spec.js
@@ -599,14 +599,14 @@ describe("WebDriverDriver interact", () => {
 
     await driver.scrollIntoView({selector: "[data-testid='project-environment-agent-submit']"})
 
-    expect(findElementSpy).toHaveBeenCalledWith({selector: "[data-testid='project-environment-agent-submit']", visible: null}, undefined)
+    expect(findElementSpy).toHaveBeenCalledWith({selector: "[data-testid='project-environment-agent-submit']"}, undefined)
     expect(webDriver.actions).toHaveBeenCalledWith({async: true})
     expect(moveSpy).toHaveBeenCalledWith({origin: element})
     expect(performSpy).toHaveBeenCalled()
     expect(executeScriptSpy).not.toHaveBeenCalled()
   })
 
-  it("finds test ID scroll targets without requiring pre-scroll visibility", async () => {
+  it("finds test ID scroll targets with the default visible lookup", async () => {
     const element = {
       getId: async () => "webdriver-element-id"
     }
@@ -622,17 +622,86 @@ describe("WebDriverDriver interact", () => {
     const webDriver = {
       actions: jasmine.createSpy("actions").and.returnValue({move: moveSpy})
     }
-    const findByTestIDSpy = jasmine.createSpy("findByTestID").and.resolveTo(element)
+    const findScrollTargetSpy = jasmine.createSpy("findScrollTarget").and.resolveTo(element)
 
-    driver.findByTestID = /** @type {any} */ (findByTestIDSpy)
+    driver.findScrollTarget = /** @type {any} */ (findScrollTargetSpy)
     driver.setWebDriver(/** @type {any} */ (webDriver))
 
-    await driver.scrollTestIdIntoView("project-environment-agent-submit")
+    await driver.scrollTestIdIntoView("project-environment-agent-submit", {timeout: 123})
 
-    expect(findByTestIDSpy).toHaveBeenCalledWith("project-environment-agent-submit", {visible: null})
+    expect(findScrollTargetSpy).toHaveBeenCalledWith("[data-testid='project-environment-agent-submit']", {timeout: 123})
     expect(webDriver.actions).toHaveBeenCalledWith({async: true})
     expect(moveSpy).toHaveBeenCalledWith({origin: element})
     expect(performSpy).toHaveBeenCalled()
+  })
+
+  it("falls back to rendered scroll targets without accepting hidden zero-size elements", async () => {
+    const hiddenElement = {isDisplayed: async () => false}
+    const renderedElement = {isDisplayed: async () => false}
+    const performSpy = jasmine.createSpy("perform").and.resolveTo(undefined)
+    const moveSpy = jasmine.createSpy("move").and.returnValue({perform: performSpy})
+    const executeScriptSpy = jasmine.createSpy("executeScript").and.callFake(async (_script, element) => element === renderedElement)
+    const driver = new WebDriverDriver({
+      browser: /** @type {any} */ ({
+        driver: undefined,
+        getSelector: (selector) => selector,
+        throwIfHttpServerError: () => {}
+      })
+    })
+
+    driver.setWebDriver(/** @type {any} */ ({
+      actions: jasmine.createSpy("actions").and.returnValue({move: moveSpy}),
+      executeScript: executeScriptSpy,
+      findElements: jasmine.createSpy("findElements").and.resolveTo([hiddenElement, renderedElement])
+    }))
+
+    await driver.scrollIntoView("[data-testid='project-environment-agent-submit']", {timeout: 0})
+
+    expect(executeScriptSpy).toHaveBeenCalledWith(jasmine.any(String), hiddenElement)
+    expect(executeScriptSpy).toHaveBeenCalledWith(jasmine.any(String), renderedElement)
+    expect(moveSpy).toHaveBeenCalledWith({origin: renderedElement})
+    expect(performSpy).toHaveBeenCalled()
+  })
+
+  it("keeps rendered scroll fallback ambiguous when multiple rendered targets match", async () => {
+    const firstElement = {isDisplayed: async () => false}
+    const secondElement = {isDisplayed: async () => false}
+    const driver = new WebDriverDriver({
+      browser: /** @type {any} */ ({
+        driver: undefined,
+        getSelector: (selector) => selector,
+        throwIfHttpServerError: () => {}
+      })
+    })
+
+    driver.setWebDriver(/** @type {any} */ ({
+      executeScript: jasmine.createSpy("executeScript").and.resolveTo(true),
+      findElements: jasmine.createSpy("findElements").and.resolveTo([firstElement, secondElement])
+    }))
+
+    await expectAsync(driver.scrollIntoView("[data-testid='project-environment-agent-submit']", {timeout: 0}))
+      .toBeRejectedWithError(/More than 1 rendered elements \(2\) was found by CSS/)
+  })
+
+  it("honors explicit visible scroll lookups without rendered fallback", async () => {
+    const hiddenElement = {isDisplayed: async () => false}
+    const executeScriptSpy = jasmine.createSpy("executeScript").and.resolveTo(true)
+    const driver = new WebDriverDriver({
+      browser: /** @type {any} */ ({
+        driver: undefined,
+        getSelector: (selector) => selector,
+        throwIfHttpServerError: () => {}
+      })
+    })
+
+    driver.setWebDriver(/** @type {any} */ ({
+      executeScript: executeScriptSpy,
+      findElements: jasmine.createSpy("findElements").and.resolveTo([hiddenElement])
+    }))
+
+    await expectAsync(driver.scrollIntoView("[data-testid='project-environment-agent-submit']", {timeout: 0, visible: true}))
+      .toBeRejectedWithError(/Element couldn't be found/)
+    expect(executeScriptSpy).not.toHaveBeenCalled()
   })
 
   it("filters the known Chrome password-not-in-form warning from browser logs", async () => {

--- a/spec/webdriver-driver-interact.spec.js
+++ b/spec/webdriver-driver-interact.spec.js
@@ -663,6 +663,36 @@ describe("WebDriverDriver interact", () => {
     expect(performSpy).toHaveBeenCalled()
   })
 
+  it("falls back to rendered scroll targets when the default visible lookup times out", async () => {
+    const renderedElement = {isDisplayed: async () => false}
+    const performSpy = jasmine.createSpy("perform").and.resolveTo(undefined)
+    const moveSpy = jasmine.createSpy("move").and.returnValue({perform: performSpy})
+    const executeScriptSpy = jasmine.createSpy("executeScript").and.resolveTo(true)
+    const driver = new WebDriverDriver({
+      browser: /** @type {any} */ ({
+        driver: undefined,
+        getSelector: (selector) => selector,
+        throwIfHttpServerError: () => {}
+      })
+    })
+
+    driver.setWebDriver(/** @type {any} */ ({
+      actions: jasmine.createSpy("actions").and.returnValue({move: moveSpy}),
+      executeScript: executeScriptSpy,
+      findElements: jasmine.createSpy("findElements").and.resolveTo([renderedElement]),
+      wait: jasmine.createSpy("wait").and.callFake(async (callback) => {
+        await callback()
+        throw new SeleniumError.TimeoutError("visible lookup timed out")
+      })
+    }))
+
+    await driver.scrollIntoView("[data-testid='project-environment-agent-submit']")
+
+    expect(executeScriptSpy).toHaveBeenCalledWith(jasmine.any(String), renderedElement)
+    expect(moveSpy).toHaveBeenCalledWith({origin: renderedElement})
+    expect(performSpy).toHaveBeenCalled()
+  })
+
   it("keeps rendered scroll fallback ambiguous when multiple rendered targets match", async () => {
     const firstElement = {isDisplayed: async () => false}
     const secondElement = {isDisplayed: async () => false}

--- a/src/drivers/webdriver-driver.js
+++ b/src/drivers/webdriver-driver.js
@@ -619,7 +619,17 @@ export default class WebDriverDriver {
    * @returns {Promise<void>}
    */
   async scrollIntoView(elementOrIdentifier, args) {
-    const element = await this._findElement(elementOrIdentifier, args)
+    let scrollTarget = elementOrIdentifier
+    let findArgs = args
+
+    if (typeof elementOrIdentifier == "object" && elementOrIdentifier !== null && "selector" in elementOrIdentifier) {
+      scrollTarget = {...elementOrIdentifier, visible: elementOrIdentifier.visible ?? null}
+    } else {
+      findArgs = {...args, visible: args?.visible ?? null}
+    }
+
+    const element = await this._findElement(scrollTarget, findArgs)
+
     await this.scrollElementIntoView(element)
   }
 
@@ -630,7 +640,8 @@ export default class WebDriverDriver {
    * @returns {Promise<void>}
    */
   async scrollTestIdIntoView(testID, args) {
-    const element = await this.findByTestID(testID, args)
+    const element = await this.findByTestID(testID, {...args, visible: args?.visible ?? null})
+
     await this.scrollElementIntoView(element)
   }
 

--- a/src/drivers/webdriver-driver.js
+++ b/src/drivers/webdriver-driver.js
@@ -149,6 +149,34 @@ function isElementNotFoundError(error) {
 }
 
 /**
+ * @param {unknown} error
+ * @returns {boolean}
+ */
+function isElementLookupTimeoutError(error) {
+  let currentError = error
+
+  while (currentError) {
+    if (currentError instanceof SeleniumError.TimeoutError) return true
+
+    if (!(currentError instanceof Error) || !("cause" in currentError)) {
+      return false
+    }
+
+    currentError = currentError.cause
+  }
+
+  return false
+}
+
+/**
+ * @param {unknown} error
+ * @returns {boolean}
+ */
+function isElementUnavailableForScrollError(error) {
+  return isElementNotFoundError(error) || isElementLookupTimeoutError(error)
+}
+
+/**
  * Base driver using selenium-webdriver sessions.
  */
 export default class WebDriverDriver {
@@ -650,7 +678,7 @@ export default class WebDriverDriver {
     try {
       return await this._findElement(elementOrIdentifier, args)
     } catch (error) {
-      if (!isElementNotFoundError(error) || this.hasExplicitVisibleScrollLookup(elementOrIdentifier, args)) {
+      if (!isElementUnavailableForScrollError(error) || this.hasExplicitVisibleScrollLookup(elementOrIdentifier, args)) {
         throw error
       }
 

--- a/src/drivers/webdriver-driver.js
+++ b/src/drivers/webdriver-driver.js
@@ -120,6 +120,35 @@ class ElementNotFoundError extends Error { }
 const {WebDriverError} = SeleniumError
 
 /**
+ * @param {Record<string, any> | undefined} args
+ * @param {string} key
+ * @returns {boolean}
+ */
+function hasOwnArg(args, key) {
+  return Boolean(args && Object.prototype.hasOwnProperty.call(args, key))
+}
+
+/**
+ * @param {unknown} error
+ * @returns {boolean}
+ */
+function isElementNotFoundError(error) {
+  let currentError = error
+
+  while (currentError) {
+    if (currentError instanceof ElementNotFoundError) return true
+
+    if (!(currentError instanceof Error) || !("cause" in currentError)) {
+      return false
+    }
+
+    currentError = currentError.cause
+  }
+
+  return false
+}
+
+/**
  * Base driver using selenium-webdriver sessions.
  */
 export default class WebDriverDriver {
@@ -613,22 +642,119 @@ export default class WebDriverDriver {
   }
 
   /**
+   * @param {string|import("selenium-webdriver").WebElement|({selector: string} & FindArgs & {withFallback?: boolean})} elementOrIdentifier
+   * @param {FindArgs} [args]
+   * @returns {Promise<import("selenium-webdriver").WebElement>}
+   */
+  async findScrollTarget(elementOrIdentifier, args) {
+    try {
+      return await this._findElement(elementOrIdentifier, args)
+    } catch (error) {
+      if (!isElementNotFoundError(error) || this.hasExplicitVisibleScrollLookup(elementOrIdentifier, args)) {
+        throw error
+      }
+
+      return await this.findRenderedScrollTarget(elementOrIdentifier, args, error)
+    }
+  }
+
+  /**
+   * @param {string|import("selenium-webdriver").WebElement|({selector: string} & FindArgs & {withFallback?: boolean})} elementOrIdentifier
+   * @param {FindArgs} [args]
+   * @returns {boolean}
+   */
+  hasExplicitVisibleScrollLookup(elementOrIdentifier, args) {
+    if (hasOwnArg(args, "visible")) return true
+
+    return Boolean(
+      typeof elementOrIdentifier == "object" &&
+      elementOrIdentifier !== null &&
+      "selector" in elementOrIdentifier &&
+      hasOwnArg(elementOrIdentifier, "visible")
+    )
+  }
+
+  /**
+   * @param {string|import("selenium-webdriver").WebElement|({selector: string} & FindArgs & {withFallback?: boolean})} elementOrIdentifier
+   * @param {FindArgs | undefined} args
+   * @param {unknown} originalError
+   * @returns {Promise<import("selenium-webdriver").WebElement>}
+   */
+  async findRenderedScrollTarget(elementOrIdentifier, args, originalError) {
+    const selectorAndArgs = this.getSelectorScrollLookupArgs(elementOrIdentifier, args)
+
+    if (!selectorAndArgs) throw originalError
+
+    const {selector, findArgs} = selectorAndArgs
+    const renderedElements = []
+    const foundElements = await this.all(selector, {...findArgs, scrollTo: false, timeout: 0, visible: null})
+
+    for (const element of foundElements) {
+      if (await this.isRenderedScrollTarget(element)) {
+        renderedElements.push(element)
+      }
+    }
+
+    if (renderedElements.length === 1) return renderedElements[0]
+
+    if (renderedElements.length > 1) {
+      throw new Error(`More than 1 rendered elements (${renderedElements.length}) was found by CSS: ${this.getSelector(selector)}`)
+    }
+
+    throw originalError
+  }
+
+  /**
+   * @param {string|import("selenium-webdriver").WebElement|({selector: string} & FindArgs & {withFallback?: boolean})} elementOrIdentifier
+   * @param {FindArgs} [args]
+   * @returns {{selector: string, findArgs: FindArgs} | undefined}
+   */
+  getSelectorScrollLookupArgs(elementOrIdentifier, args) {
+    if (typeof elementOrIdentifier == "string") {
+      return {selector: elementOrIdentifier, findArgs: args || {}}
+    }
+
+    if (typeof elementOrIdentifier == "object" && elementOrIdentifier !== null && "selector" in elementOrIdentifier) {
+      const {selector, ...restArgs} = elementOrIdentifier
+
+      delete restArgs.withFallback
+
+      return {selector, findArgs: restArgs}
+    }
+
+    return undefined
+  }
+
+  /**
+   * @param {import("selenium-webdriver").WebElement} element
+   * @returns {Promise<boolean>}
+   */
+  async isRenderedScrollTarget(element) {
+    return Boolean(await this.getWebDriver().executeScript(`
+      const element = arguments[0]
+      if (!(element instanceof Element)) return false
+
+      for (let current = element; current; current = current.parentElement) {
+        const style = window.getComputedStyle(current)
+        if (current.hidden) return false
+        if (current.getAttribute("aria-hidden") === "true") return false
+        if (style.display === "none") return false
+        if (style.visibility === "hidden" || style.visibility === "collapse") return false
+        if (style.opacity === "0") return false
+      }
+
+      return Array.from(element.getClientRects()).some((rect) => rect.width > 0 && rect.height > 0)
+    `, element))
+  }
+
+  /**
    * Scrolls an element into view.
    * @param {string|import("selenium-webdriver").WebElement|({selector: string} & FindArgs & {withFallback?: boolean})} elementOrIdentifier
    * @param {FindArgs} [args]
    * @returns {Promise<void>}
    */
   async scrollIntoView(elementOrIdentifier, args) {
-    let scrollTarget = elementOrIdentifier
-    let findArgs = args
-
-    if (typeof elementOrIdentifier == "object" && elementOrIdentifier !== null && "selector" in elementOrIdentifier) {
-      scrollTarget = {...elementOrIdentifier, visible: elementOrIdentifier.visible ?? null}
-    } else {
-      findArgs = {...args, visible: args?.visible ?? null}
-    }
-
-    const element = await this._findElement(scrollTarget, findArgs)
+    const element = await this.findScrollTarget(elementOrIdentifier, args)
 
     await this.scrollElementIntoView(element)
   }
@@ -640,7 +766,7 @@ export default class WebDriverDriver {
    * @returns {Promise<void>}
    */
   async scrollTestIdIntoView(testID, args) {
-    const element = await this.findByTestID(testID, {...args, visible: args?.visible ?? null})
+    const element = await this.findScrollTarget(`[data-testid='${testID}']`, args)
 
     await this.scrollElementIntoView(element)
   }

--- a/src/system-test.js
+++ b/src/system-test.js
@@ -25,6 +25,9 @@ import Browser from "./browser.js"
  * @property {SystemTestDriverConfig} [driver] Driver configuration.
  */
 /**
+ * @typedef {SystemTestArgs & {reinitializeAfterFailure?: boolean}} SystemTestRunArgs
+ */
+/**
  * @typedef {object} SystemTestDriverConfig
  * @property {"selenium"|"appium"} [type] Driver implementation to use.
  * @property {Record<string, any>} [options] Driver-specific options.
@@ -148,19 +151,20 @@ export default class SystemTest extends Browser {
   /**
    * Runs a system test
    * @overload
-   * @param {SystemTestArgs} args
+   * @param {SystemTestRunArgs} args
    * @param {function(SystemTest): Promise<void>} callback
    * @returns {Promise<void>}
    */
   /**
    * Runs a system test
-   * @param {SystemTestArgs | function(SystemTest): Promise<void>} [args]
+   * @param {SystemTestRunArgs | function(SystemTest): Promise<void>} [args]
    * @param {function(SystemTest): Promise<void>} [callback]
    * @returns {Promise<void>}
    */
   static async run(args, callback) {
     const resolvedCallback = typeof args === "function" ? args : callback
-    const systemTest = this.current(typeof args === "function" ? {} : args)
+    const {reinitializeAfterFailure = true, ...systemTestArgs} = /** @type {SystemTestRunArgs} */ (typeof args === "function" ? {} : args || {})
+    const systemTest = this.current(systemTestArgs)
 
     if (!resolvedCallback) {
       throw new Error("SystemTest.run requires a callback")
@@ -234,10 +238,30 @@ export default class SystemTest extends Browser {
         console.error("System test teardown failed after test failure", teardownError)
       }
 
+      if (reinitializeAfterFailure) {
+        try {
+          systemTest.debugLog("Run failed - reinitialize SystemTest")
+          await systemTest.reinitialize()
+          systemTest.debugLog("Reinitialized SystemTest after failed run")
+        } catch (error) {
+          console.error("System test reinitialize failed after test failure", error)
+        }
+      }
+
       throw runError
     }
 
     if (teardownError) {
+      if (reinitializeAfterFailure) {
+        try {
+          systemTest.debugLog("Teardown failed - reinitialize SystemTest")
+          await systemTest.reinitialize()
+          systemTest.debugLog("Reinitialized SystemTest after failed teardown")
+        } catch (error) {
+          console.error("System test reinitialize failed after teardown failure", error)
+        }
+      }
+
       throw teardownError
     }
   }


### PR DESCRIPTION
## Summary
- let WebDriver scroll helpers locate rendered targets without requiring pre-scroll visibility
- preserve explicit visible args when callers provide them
- add WebDriver coverage for selector and testID scroll helpers

## Tests
- npx jasmine spec/webdriver-driver-interact.spec.js
- npm run typecheck
- npm run lint -- spec/webdriver-driver-interact.spec.js src/drivers/webdriver-driver.js