### PR TITLE
Add browser path wait helper

### DIFF
--- a/spec/browser.spec.js
+++ b/spec/browser.spec.js
@@ -38,6 +38,21 @@ describe("Browser", () => {
     expect(visitedPaths).toEqual(["https://example.com"])
   })
 
+  it("waits for the current URL pathname", async () => {
+    const browser = new Browser()
+    const urls = [
+      "https://example.com/invoices/1/edit?token=abc",
+      "https://example.com/invoices/1?token=abc"
+    ]
+
+    browser.driverAdapter = /** @type {any} */ ({
+      getCurrentUrl: async () => urls.shift() || "https://example.com/invoices/1?token=abc",
+      getTimeouts: () => 500
+    })
+
+    await browser.waitForPath("/invoices/1")
+  })
+
   it("deletes all cookies through the driver adapter", async () => {
     const browser = new Browser()
     let deleteAllCookiesCalls = 0

--- a/src/browser.js
+++ b/src/browser.js
@@ -4,6 +4,7 @@ import fs from "node:fs/promises"
 import {Key} from "selenium-webdriver"
 import moment from "moment"
 import {prettify} from "htmlfy"
+import {waitFor} from "awaitery"
 import timeout from "awaitery/build/timeout.js"
 import SeleniumDriver from "./drivers/selenium-driver.js"
 import AppiumDriver from "./drivers/appium-driver.js"
@@ -23,6 +24,10 @@ import AppiumDriver from "./drivers/appium-driver.js"
 /**
  * @typedef {object} BrowserNavigationArgs
  * @property {number} [timeout] Override the timeout for this navigation command.
+ */
+/**
+ * @typedef {object} BrowserPathWaitArgs
+ * @property {number} [timeout] Override the timeout for this path wait.
  */
 
 /** Generic browser session wrapper around the configured driver. */
@@ -189,6 +194,23 @@ export default class Browser {
   /** @returns {Promise<string>} */
   async getCurrentUrl() {
     return await this.getDriverAdapter().getCurrentUrl()
+  }
+
+  /**
+   * Waits until the current URL pathname exactly matches the expected path.
+   * @param {string} expectedPath
+   * @param {BrowserPathWaitArgs} [args]
+   * @returns {Promise<void>}
+   */
+  async waitForPath(expectedPath, args = {}) {
+    await waitFor({timeout: this.getCommandTimeout(args.timeout)}, async () => {
+      const currentUrl = await this.getCurrentUrl()
+      const currentPath = new URL(currentUrl).pathname
+
+      if (currentPath !== expectedPath) {
+        throw new Error(`Timed out waiting for path ${expectedPath}. Current URL: ${currentUrl}`)
+      }
+    })
   }
 
   /**


### PR DESCRIPTION
## Summary
- add `Browser#waitForPath` for exact pathname waits that ignore query strings
- cover the helper in the browser unit spec

## Validation
- `npm run typecheck`
- `npm run lint`
- `npx jasmine spec/browser.spec.js`