### PR TITLE
Add shared browser assertion helpers

### DIFF
--- a/spec/browser.spec.js
+++ b/spec/browser.spec.js
@@ -73,6 +73,7 @@ describe("Browser", () => {
 
   it("waits for text on elements by test id", async () => {
     const browser = new Browser()
+    const findArgs = []
     const texts = [
       "Loading",
       "Ready",
@@ -81,14 +82,25 @@ describe("Browser", () => {
     ]
 
     browser.driverAdapter = /** @type {any} */ ({
-      findByTestID: async () => ({
-        getText: async () => texts.shift() || "Fresh text"
-      }),
+      findByTestID: async (_testID, args) => {
+        findArgs.push(args)
+
+        return {
+          getText: async () => texts.shift() || "Fresh text"
+        }
+      },
       getTimeouts: () => 500
     })
 
     await browser.waitForTestIDText("statusText", "Ready")
     await browser.waitForTestIDTextExcludes("statusText", "stale")
+
+    expect(findArgs).toEqual([
+      {timeout: 0},
+      {timeout: 0},
+      {timeout: 0},
+      {timeout: 0}
+    ])
   })
 
   it("asserts CSS colors by test id", async () => {
@@ -101,6 +113,20 @@ describe("Browser", () => {
     })
 
     await browser.expectTestIDCssColor("panel", "background-color", "30, 41, 59", "255, 255, 255", "panel")
+  })
+
+  it("rejects CSS color substring matches by test id", async () => {
+    const browser = new Browser()
+
+    browser.driverAdapter = /** @type {any} */ ({
+      findByTestID: async () => ({
+        getCssValue: async () => "rgb(130, 41, 59)"
+      })
+    })
+
+    await expectAsync(
+      browser.expectTestIDCssColor("panel", "background-color", "30, 41, 59", "255, 255, 255", "panel")
+    ).toBeRejectedWithError("Expected panel to include rgb(30, 41, 59), got background-color rgb(130, 41, 59)")
   })
 
   it("replaces input values by test id through shared retryable interactions", async () => {

--- a/spec/browser.spec.js
+++ b/spec/browser.spec.js
@@ -53,6 +53,84 @@ describe("Browser", () => {
     await browser.waitForPath("/invoices/1")
   })
 
+  it("waits for exact and fragment URL assertions", async () => {
+    const browser = new Browser()
+    const urls = [
+      "https://example.com/invoices?filter=open",
+      "https://example.com/invoices?filter=closed",
+      "https://example.com/invoices?filter=closed"
+    ]
+
+    browser.driverAdapter = /** @type {any} */ ({
+      getCurrentUrl: async () => urls.shift() || "https://example.com/invoices?filter=closed",
+      getTimeouts: () => 500
+    })
+
+    await browser.waitForUrlContains("filter=closed")
+    await browser.waitForUrlExcludes("filter=open")
+    await browser.waitForCurrentUrl("https://example.com/invoices?filter=closed")
+  })
+
+  it("waits for text on elements by test id", async () => {
+    const browser = new Browser()
+    const texts = [
+      "Loading",
+      "Ready",
+      "Removing stale text",
+      "Fresh text"
+    ]
+
+    browser.driverAdapter = /** @type {any} */ ({
+      findByTestID: async () => ({
+        getText: async () => texts.shift() || "Fresh text"
+      }),
+      getTimeouts: () => 500
+    })
+
+    await browser.waitForTestIDText("statusText", "Ready")
+    await browser.waitForTestIDTextExcludes("statusText", "stale")
+  })
+
+  it("asserts CSS colors by test id", async () => {
+    const browser = new Browser()
+
+    browser.driverAdapter = /** @type {any} */ ({
+      findByTestID: async () => ({
+        getCssValue: async () => "rgb(30 41 59 / 1)"
+      })
+    })
+
+    await browser.expectTestIDCssColor("panel", "background-color", "30, 41, 59", "255, 255, 255", "panel")
+  })
+
+  it("replaces input values by test id through shared retryable interactions", async () => {
+    const browser = new Browser()
+    const calls = []
+
+    browser.interact = /** @type {any} */ (async (...args) => {
+      calls.push(args)
+    })
+
+    await browser.replaceTestIDInputValue("name\"Input", "Next value", {timeout: 250})
+
+    expect(calls.length).toEqual(2)
+    expect(calls[0]).toEqual([
+      {
+        selector: "[data-testid=\"name\\\"Input\"]",
+        timeout: 250,
+        withFallback: true
+      },
+      "click"
+    ])
+    expect(calls[1][0]).toEqual({
+      selector: "[data-testid=\"name\\\"Input\"]",
+      timeout: 250,
+      withFallback: true
+    })
+    expect(calls[1][1]).toEqual("sendKeys")
+    expect(calls[1][4]).toEqual("Next value")
+  })
+
   it("deletes all cookies through the driver adapter", async () => {
     const browser = new Browser()
     let deleteAllCookiesCalls = 0

--- a/src/browser.js
+++ b/src/browser.js
@@ -29,6 +29,50 @@ import AppiumDriver from "./drivers/appium-driver.js"
  * @typedef {object} BrowserPathWaitArgs
  * @property {number} [timeout] Override the timeout for this path wait.
  */
+/**
+ * @typedef {object} BrowserTextWaitArgs
+ * @property {number} [timeout] Override the timeout for this text wait.
+ */
+/**
+ * @typedef {object} BrowserCurrentUrlWaitArgs
+ * @property {number} [timeout] Override the timeout for this URL wait.
+ */
+/**
+ * @typedef {object} BrowserTestIDInputArgs
+ * @property {number} [timeout] Override timeout for the input lookup.
+ */
+
+/**
+ * Builds a data-testid CSS selector.
+ * @param {string} testID Raw value from a `data-testid` attribute.
+ * @returns {string} CSS attribute selector.
+ */
+function testIdSelector(testID) {
+  return `[data-testid="${cssAttributeValue(testID)}"]`
+}
+
+/**
+ * Escapes a value for use inside a double-quoted CSS attribute selector.
+ * @param {string | number} value Raw attribute value.
+ * @returns {string} Escaped selector value.
+ */
+function cssAttributeValue(value) {
+  return String(value).replace(/\\/g, "\\\\").replace(/"/g, "\\\"")
+}
+
+/**
+ * Checks whether a browser-normalized CSS color contains the RGB triplet.
+ * @param {string} actualValue Browser-normalized CSS color.
+ * @param {string} rgbFragment RGB fragment like `30, 41, 59`.
+ * @returns {boolean} Whether the fragment appears.
+ */
+function cssValueContainsRgb(actualValue, rgbFragment) {
+  const spaceSeparatedRgb = rgbFragment.replace(/, /g, " ")
+
+  return actualValue.includes(rgbFragment) ||
+    actualValue.includes(`rgb(${spaceSeparatedRgb}`) ||
+    actualValue.includes(`rgba(${spaceSeparatedRgb}`)
+}
 
 /** Generic browser session wrapper around the configured driver. */
 export default class Browser {
@@ -214,6 +258,54 @@ export default class Browser {
   }
 
   /**
+   * Waits until the current URL exactly matches the expected URL.
+   * @param {string} expectedUrl Exact URL expected.
+   * @param {BrowserCurrentUrlWaitArgs} [args] Optional timeout.
+   * @returns {Promise<void>}
+   */
+  async waitForCurrentUrl(expectedUrl, args = {}) {
+    await waitFor({timeout: this.getCommandTimeout(args.timeout)}, async () => {
+      const currentUrl = await this.getCurrentUrl()
+
+      if (currentUrl !== expectedUrl) {
+        throw new Error(`Timed out waiting for URL ${expectedUrl}. Current URL: ${currentUrl}`)
+      }
+    })
+  }
+
+  /**
+   * Waits until the current URL contains a fragment.
+   * @param {string} expectedFragment Fragment that should appear.
+   * @param {BrowserCurrentUrlWaitArgs} [args] Optional timeout.
+   * @returns {Promise<void>}
+   */
+  async waitForUrlContains(expectedFragment, args = {}) {
+    await waitFor({timeout: this.getCommandTimeout(args.timeout)}, async () => {
+      const currentUrl = await this.getCurrentUrl()
+
+      if (!currentUrl.includes(expectedFragment)) {
+        throw new Error(`Timed out waiting for URL to include ${expectedFragment}. Current URL: ${currentUrl}`)
+      }
+    })
+  }
+
+  /**
+   * Waits until the current URL does not contain a fragment.
+   * @param {string} unexpectedFragment Fragment that should disappear.
+   * @param {BrowserCurrentUrlWaitArgs} [args] Optional timeout.
+   * @returns {Promise<void>}
+   */
+  async waitForUrlExcludes(unexpectedFragment, args = {}) {
+    await waitFor({timeout: this.getCommandTimeout(args.timeout)}, async () => {
+      const currentUrl = await this.getCurrentUrl()
+
+      if (currentUrl.includes(unexpectedFragment)) {
+        throw new Error(`Timed out waiting for URL to exclude ${unexpectedFragment}. Current URL: ${currentUrl}`)
+      }
+    })
+  }
+
+  /**
    * @param {string} selector
    * @param {import("./system-test.js").FindArgs} [args]
    * @returns {Promise<import("selenium-webdriver").WebElement[]>}
@@ -277,6 +369,78 @@ export default class Browser {
   async clearAndSendKeys(elementOrIdentifier, nextValue) {
     await this.interact(elementOrIdentifier, "click")
     await this.interact(elementOrIdentifier, "sendKeys", Key.chord(Key.CONTROL, "a"), Key.BACK_SPACE, nextValue)
+  }
+
+  /**
+   * Replaces an input-like element's value by test id.
+   * @param {string} testID Field `data-testid` to target.
+   * @param {string} nextValue Text to leave in the field.
+   * @param {BrowserTestIDInputArgs} [args] Optional lookup timeout.
+   * @returns {Promise<void>}
+   */
+  async replaceTestIDInputValue(testID, nextValue, args = {}) {
+    await this.clearAndSendKeys({
+      selector: testIdSelector(testID),
+      timeout: args.timeout,
+      withFallback: true
+    }, nextValue)
+  }
+
+  /**
+   * Waits until a test id contains expected visible text.
+   * @param {string} testID Element `data-testid` to inspect.
+   * @param {string} expectedText Fragment that must appear in the element text.
+   * @param {BrowserTextWaitArgs} [args] Optional timeout.
+   * @returns {Promise<void>}
+   */
+  async waitForTestIDText(testID, expectedText, args = {}) {
+    await waitFor({timeout: this.getCommandTimeout(args.timeout)}, async () => {
+      const element = await this.findByTestID(testID)
+      const actualText = await element.getText()
+
+      if (!actualText.includes(expectedText)) {
+        throw new Error(`Timed out waiting for text ${expectedText}. Last text was ${actualText}`)
+      }
+    })
+  }
+
+  /**
+   * Waits until a test id no longer contains excluded visible text.
+   * @param {string} testID Element `data-testid` to inspect.
+   * @param {string} excludedText Fragment that should disappear from the element text.
+   * @param {BrowserTextWaitArgs} [args] Optional timeout.
+   * @returns {Promise<void>}
+   */
+  async waitForTestIDTextExcludes(testID, excludedText, args = {}) {
+    await waitFor({timeout: this.getCommandTimeout(args.timeout)}, async () => {
+      const element = await this.findByTestID(testID)
+      const actualText = await element.getText()
+
+      if (actualText.includes(excludedText)) {
+        throw new Error(`Timed out waiting for text to exclude ${excludedText}. Last text was ${actualText}`)
+      }
+    })
+  }
+
+  /**
+   * Asserts a rendered element has a CSS color from the expected palette.
+   * @param {string} testID Element `data-testid` to inspect.
+   * @param {string} propertyName CSS property to read.
+   * @param {string} expectedRgb Expected RGB fragment.
+   * @param {string} lightRgb Disallowed RGB fragment.
+   * @param {string} description Human-readable element description.
+   * @returns {Promise<void>}
+   */
+  async expectTestIDCssColor(testID, propertyName, expectedRgb, lightRgb, description) {
+    const element = await this.findByTestID(testID)
+    const actualValue = await element.getCssValue(propertyName)
+
+    if (cssValueContainsRgb(actualValue, lightRgb)) {
+      throw new Error(`Expected ${description} to avoid the light palette, got ${propertyName} ${actualValue}`)
+    }
+    if (!cssValueContainsRgb(actualValue, expectedRgb)) {
+      throw new Error(`Expected ${description} to include rgb(${expectedRgb}), got ${propertyName} ${actualValue}`)
+    }
   }
 
   /**

--- a/src/browser.js
+++ b/src/browser.js
@@ -61,17 +61,38 @@ function cssAttributeValue(value) {
 }
 
 /**
- * Checks whether a browser-normalized CSS color contains the RGB triplet.
+ * Extracts the RGB channels from CSS `rgb(...)`/`rgba(...)` values or an RGB fragment.
+ * @param {string} value CSS color value or RGB fragment like `30, 41, 59`.
+ * @returns {[number, number, number] | undefined}
+ */
+function cssRgbChannels(value) {
+  const rgbMatch = value.match(/rgba?\(([^)]+)\)/)
+  const channelsValue = rgbMatch ? rgbMatch[1] : value
+  const channels = channelsValue
+    .replace(/\s*\/.*$/, "")
+    .split(/[,\s]+/)
+    .filter(Boolean)
+    .slice(0, 3)
+    .map((channel) => Number(channel))
+
+  if (channels.length !== 3 || channels.some((channel) => !Number.isFinite(channel))) return undefined
+
+  return /** @type {[number, number, number]} */ (channels)
+}
+
+/**
+ * Checks whether a browser-normalized CSS color matches the RGB triplet.
  * @param {string} actualValue Browser-normalized CSS color.
  * @param {string} rgbFragment RGB fragment like `30, 41, 59`.
- * @returns {boolean} Whether the fragment appears.
+ * @returns {boolean} Whether the RGB channels match.
  */
-function cssValueContainsRgb(actualValue, rgbFragment) {
-  const spaceSeparatedRgb = rgbFragment.replace(/, /g, " ")
+function cssValueMatchesRgb(actualValue, rgbFragment) {
+  const actualChannels = cssRgbChannels(actualValue)
+  const expectedChannels = cssRgbChannels(rgbFragment)
 
-  return actualValue.includes(rgbFragment) ||
-    actualValue.includes(`rgb(${spaceSeparatedRgb}`) ||
-    actualValue.includes(`rgba(${spaceSeparatedRgb}`)
+  if (!actualChannels || !expectedChannels) return false
+
+  return actualChannels.every((actualChannel, index) => actualChannel === expectedChannels[index])
 }
 
 /** Generic browser session wrapper around the configured driver. */
@@ -395,7 +416,7 @@ export default class Browser {
    */
   async waitForTestIDText(testID, expectedText, args = {}) {
     await waitFor({timeout: this.getCommandTimeout(args.timeout)}, async () => {
-      const element = await this.findByTestID(testID)
+      const element = await this.findByTestID(testID, {timeout: 0})
       const actualText = await element.getText()
 
       if (!actualText.includes(expectedText)) {
@@ -413,7 +434,7 @@ export default class Browser {
    */
   async waitForTestIDTextExcludes(testID, excludedText, args = {}) {
     await waitFor({timeout: this.getCommandTimeout(args.timeout)}, async () => {
-      const element = await this.findByTestID(testID)
+      const element = await this.findByTestID(testID, {timeout: 0})
       const actualText = await element.getText()
 
       if (actualText.includes(excludedText)) {
@@ -435,10 +456,10 @@ export default class Browser {
     const element = await this.findByTestID(testID)
     const actualValue = await element.getCssValue(propertyName)
 
-    if (cssValueContainsRgb(actualValue, lightRgb)) {
+    if (cssValueMatchesRgb(actualValue, lightRgb)) {
       throw new Error(`Expected ${description} to avoid the light palette, got ${propertyName} ${actualValue}`)
     }
-    if (!cssValueContainsRgb(actualValue, expectedRgb)) {
+    if (!cssValueMatchesRgb(actualValue, expectedRgb)) {
       throw new Error(`Expected ${description} to include rgb(${expectedRgb}), got ${propertyName} ${actualValue}`)
     }
   }


### PR DESCRIPTION
Summary:
- Add Browser helpers for testID text waits, URL waits, CSS color assertions, and testID input replacement.
- Cover the helpers in browser specs.

Verification:
- npm run lint
- npm run typecheck
- npm run test -- spec/browser.spec.js