### PR TITLE
Add executeScript and addCookie browser commands

### DIFF
--- a/spec/browser-command-runner.spec.js
+++ b/spec/browser-command-runner.spec.js
@@ -210,4 +210,39 @@ describe("BrowserCommandRunner", () => {
     await expectAsync(runner.run("addCookie", {name: "auth"})).toBeRejectedWithError("addCookie requires string value")
     await expectAsync(runner.run("addCookie", {name: "auth", value: 123})).toBeRejectedWithError("addCookie requires string value")
   })
+
+  it("rejects malformed boolean attributes for addCookie instead of silently coercing them", async () => {
+    const browser = {
+      addCookie: async (cookie) => {
+        browser.call = cookie
+      }
+    }
+    const runner = new BrowserCommandRunner({browser: /** @type {any} */ (browser)})
+
+    // A typo like `TRUE` or `1` previously coerced silently to `false`,
+    // which would downgrade an intended secure/httpOnly cookie without
+    // warning. Both forms must fail loudly.
+    await expectAsync(runner.run("addCookie", {name: "auth", secure: "TRUE", value: "x"})).toBeRejectedWithError(/addCookie secure must be true or false/)
+    await expectAsync(runner.run("addCookie", {httpOnly: "1", name: "auth", value: "x"})).toBeRejectedWithError(/addCookie httpOnly must be true or false/)
+    await expectAsync(runner.run("addCookie", {name: "auth", secure: 1, value: "x"})).toBeRejectedWithError(/addCookie secure must be true or false/)
+    expect(browser.call).toBeUndefined()
+  })
+
+  it("accepts native and string boolean forms for addCookie", async () => {
+    const browser = {
+      addCookie: async (cookie) => {
+        browser.calls = browser.calls || []
+        browser.calls.push(cookie)
+      }
+    }
+    const runner = new BrowserCommandRunner({browser: /** @type {any} */ (browser)})
+
+    await runner.run("addCookie", {httpOnly: true, name: "auth", secure: false, value: "x"})
+    await runner.run("addCookie", {httpOnly: "false", name: "auth", secure: "true", value: "x"})
+
+    expect(browser.calls).toEqual([
+      {httpOnly: true, name: "auth", secure: false, value: "x"},
+      {httpOnly: false, name: "auth", secure: true, value: "x"}
+    ])
+  })
 })

--- a/spec/browser-command-runner.spec.js
+++ b/spec/browser-command-runner.spec.js
@@ -146,4 +146,68 @@ describe("BrowserCommandRunner", () => {
 
     await expectAsync(runner.run("visit", {timeout: "invalid", url: "https://example.com"})).toBeRejectedWithError("Invalid timeout: invalid")
   })
+
+  it("forwards executeScript scripts and arguments to the browser and returns the resolved value", async () => {
+    const browser = {
+      executeScript: async (script, ...args) => {
+        browser.call = {args, script}
+        return "title-string"
+      }
+    }
+    const runner = new BrowserCommandRunner({browser: /** @type {any} */ (browser)})
+
+    const result = await runner.run("executeScript", {script: "return document.title", args: ["one", 2]})
+
+    expect(browser.call).toEqual({args: ["one", 2], script: "return document.title"})
+    expect(result).toEqual({result: "title-string"})
+  })
+
+  it("requires a non-empty script for executeScript", async () => {
+    const browser = {executeScript: async () => undefined}
+    const runner = new BrowserCommandRunner({browser: /** @type {any} */ (browser)})
+
+    await expectAsync(runner.run("executeScript", {})).toBeRejectedWithError("executeScript requires script")
+    await expectAsync(runner.run("executeScript", {script: ""})).toBeRejectedWithError("executeScript requires script")
+  })
+
+  it("normalizes addCookie payload fields and forwards them to the browser", async () => {
+    const browser = {
+      addCookie: async (cookie) => {
+        browser.call = cookie
+      }
+    }
+    const runner = new BrowserCommandRunner({browser: /** @type {any} */ (browser)})
+
+    const result = await runner.run("addCookie", {
+      domain: "127.0.0.1",
+      expiry: "1234567890",
+      httpOnly: "true",
+      name: "tensorbuzz_auth",
+      path: "/",
+      sameSite: "Lax",
+      secure: "false",
+      value: "encrypted-cookie-value"
+    })
+
+    expect(browser.call).toEqual({
+      domain: "127.0.0.1",
+      expiry: 1234567890,
+      httpOnly: true,
+      name: "tensorbuzz_auth",
+      path: "/",
+      sameSite: "Lax",
+      secure: false,
+      value: "encrypted-cookie-value"
+    })
+    expect(result).toEqual({ok: true})
+  })
+
+  it("requires name and value for addCookie", async () => {
+    const browser = {addCookie: async () => undefined}
+    const runner = new BrowserCommandRunner({browser: /** @type {any} */ (browser)})
+
+    await expectAsync(runner.run("addCookie", {value: "x"})).toBeRejectedWithError("addCookie requires name")
+    await expectAsync(runner.run("addCookie", {name: "auth"})).toBeRejectedWithError("addCookie requires string value")
+    await expectAsync(runner.run("addCookie", {name: "auth", value: 123})).toBeRejectedWithError("addCookie requires string value")
+  })
 })

--- a/spec/cli-helpers.spec.js
+++ b/spec/cli-helpers.spec.js
@@ -81,4 +81,44 @@ describe("cli helpers", () => {
   it("rejects invalid timeout flags", () => {
     expect(() => resolveBrowserCommand({find: ".card", timeout: "soon"})).toThrowError("Invalid timeout flag: soon")
   })
+
+  it("threads executeScript flags through the generic command path", () => {
+    expect(resolveBrowserCommand({
+      arg: ["one", "two"],
+      command: "executeScript",
+      script: "return arguments[0] + arguments[1]"
+    })).toEqual({
+      args: {
+        args: ["one", "two"],
+        script: "return arguments[0] + arguments[1]"
+      },
+      command: "executeScript"
+    })
+  })
+
+  it("threads addCookie flags through the generic command path without colliding with the daemon --name", () => {
+    // `--name` is reserved at the CLI level for the browser daemon being
+    // routed to, so cookie commands use the `cookie-` prefix instead.
+    expect(resolveBrowserCommand({
+      command: "addCookie",
+      "cookie-domain": "127.0.0.1",
+      "cookie-http-only": true,
+      "cookie-name": "tensorbuzz_auth",
+      "cookie-path": "/",
+      "cookie-same-site": "Lax",
+      "cookie-secure": false,
+      "cookie-value": "encrypted-cookie-value"
+    })).toEqual({
+      args: {
+        domain: "127.0.0.1",
+        httpOnly: true,
+        name: "tensorbuzz_auth",
+        path: "/",
+        sameSite: "Lax",
+        secure: false,
+        value: "encrypted-cookie-value"
+      },
+      command: "addCookie"
+    })
+  })
 })

--- a/src/browser-command-runner.js
+++ b/src/browser-command-runner.js
@@ -1,3 +1,20 @@
+/**
+ * Parse a cookie boolean attribute coming in over the JSON command transport.
+ * The transport carries booleans either as native `true`/`false` or as the
+ * string forms `"true"`/`"false"`. Anything else is rejected so a typo like
+ * `--cookie-secure=TRUE` or `--cookie-secure=1` fails loudly instead of
+ * silently producing an insecure cookie.
+ * @param {string} fieldName
+ * @param {unknown} rawValue
+ * @returns {boolean}
+ */
+function parseCookieBoolean(fieldName, rawValue) {
+  if (rawValue === true || rawValue === "true") return true
+  if (rawValue === false || rawValue === "false") return false
+
+  throw new Error(`addCookie ${fieldName} must be true or false, got ${JSON.stringify(rawValue)}`)
+}
+
 /** Runs browser commands across CLI and WebSocket transports. */
 export default class BrowserCommandRunner {
   /**
@@ -209,8 +226,8 @@ export default class BrowserCommandRunner {
 
       if (typeof commandArgs.domain === "string" && commandArgs.domain.length > 0) cookie.domain = commandArgs.domain
       if (typeof commandArgs.path === "string" && commandArgs.path.length > 0) cookie.path = commandArgs.path
-      if (commandArgs.secure !== undefined) cookie.secure = commandArgs.secure === true || commandArgs.secure === "true"
-      if (commandArgs.httpOnly !== undefined) cookie.httpOnly = commandArgs.httpOnly === true || commandArgs.httpOnly === "true"
+      if (commandArgs.secure !== undefined) cookie.secure = parseCookieBoolean("secure", commandArgs.secure)
+      if (commandArgs.httpOnly !== undefined) cookie.httpOnly = parseCookieBoolean("httpOnly", commandArgs.httpOnly)
       if (commandArgs.expiry !== undefined) cookie.expiry = Number(commandArgs.expiry)
       if (typeof commandArgs.sameSite === "string") cookie.sameSite = /** @type {"Strict" | "Lax" | "None"} */ (commandArgs.sameSite)
 

--- a/src/browser-command-runner.js
+++ b/src/browser-command-runner.js
@@ -178,6 +178,47 @@ export default class BrowserCommandRunner {
       return {ok: true}
     }
 
+    if (command === "executeScript") {
+      const script = commandArgs.script
+
+      if (typeof script !== "string" || script.length === 0) {
+        throw new Error("executeScript requires script")
+      }
+
+      const scriptArgs = Array.isArray(commandArgs.args) ? commandArgs.args : []
+      const result = await this.browser.executeScript(script, ...scriptArgs)
+
+      return {result}
+    }
+
+    if (command === "addCookie") {
+      const name = commandArgs.name
+
+      if (typeof name !== "string" || name.length === 0) {
+        throw new Error("addCookie requires name")
+      }
+
+      const value = commandArgs.value
+
+      if (typeof value !== "string") {
+        throw new Error("addCookie requires string value")
+      }
+
+      /** @type {{name: string, value: string, domain?: string, path?: string, secure?: boolean, httpOnly?: boolean, expiry?: number, sameSite?: "Strict" | "Lax" | "None"}} */
+      const cookie = {name, value}
+
+      if (typeof commandArgs.domain === "string" && commandArgs.domain.length > 0) cookie.domain = commandArgs.domain
+      if (typeof commandArgs.path === "string" && commandArgs.path.length > 0) cookie.path = commandArgs.path
+      if (commandArgs.secure !== undefined) cookie.secure = commandArgs.secure === true || commandArgs.secure === "true"
+      if (commandArgs.httpOnly !== undefined) cookie.httpOnly = commandArgs.httpOnly === true || commandArgs.httpOnly === "true"
+      if (commandArgs.expiry !== undefined) cookie.expiry = Number(commandArgs.expiry)
+      if (typeof commandArgs.sameSite === "string") cookie.sameSite = /** @type {"Strict" | "Lax" | "None"} */ (commandArgs.sameSite)
+
+      await this.browser.addCookie(cookie)
+
+      return {ok: true}
+    }
+
     if (command === "interact") {
       const selector = commandArgs.selector
       const methodName = commandArgs.methodName ?? commandArgs.method

--- a/src/browser.js
+++ b/src/browser.js
@@ -363,6 +363,51 @@ export default class Browser {
   }
 
   /**
+   * Add a cookie to the active driver session for the current document
+   * origin. Useful when an out-of-band login (curl, fetch, etc.) returned
+   * a `Set-Cookie` value and the test needs the browser to start
+   * authenticated without driving the sign-in UI.
+   *
+   * The driver must already be on a page whose origin/domain matches the
+   * cookie domain, otherwise Selenium will reject the call.
+   * @param {{name: string, value: string, domain?: string, path?: string, secure?: boolean, httpOnly?: boolean, expiry?: number, sameSite?: "Strict" | "Lax" | "None"}} cookie
+   * @returns {Promise<void>}
+   */
+  async addCookie(cookie) {
+    if (!cookie || typeof cookie.name !== "string" || cookie.name.length === 0) {
+      throw new Error("addCookie requires a non-empty `name`")
+    }
+
+    if (typeof cookie.value !== "string") {
+      throw new Error("addCookie requires a string `value`")
+    }
+
+    await this.getDriver().manage().addCookie(cookie)
+  }
+
+  /**
+   * Run an arbitrary script in the active browser session and return the
+   * resolved value. `script` is the function body executed in the browser
+   * (`new Function("...")`-style); `args` are forwarded as `arguments[i]`.
+   * Asynchronous scripts must `return` a Promise, which Selenium awaits.
+   *
+   * Useful for verification flows that need to call into application code
+   * (e.g. `fetch("/development/sign-in", {...})`) without going through the
+   * UI, or to read browser state the existing finder/interact commands
+   * don't expose.
+   * @param {string} script
+   * @param {...any} args
+   * @returns {Promise<any>}
+   */
+  async executeScript(script, ...args) {
+    if (typeof script !== "string" || script.length === 0) {
+      throw new Error("executeScript requires a non-empty `script` string")
+    }
+
+    return await this.getDriver().executeScript(script, ...args)
+  }
+
+  /**
    * @param {string} type
    * @param {string} path
    * @param {BrowserNavigationArgs} [args]

--- a/src/cli-helpers.js
+++ b/src/cli-helpers.js
@@ -222,6 +222,18 @@ export function resolveBrowserCommand(flags) {
     if (flags["scroll-to"] !== undefined) args.scrollTo = flags["scroll-to"]
     if (flags.visible !== undefined) args.visible = flags.visible
     if (flags["use-base-selector"] !== undefined) args.useBaseSelector = flags["use-base-selector"]
+    if (flags.script) args.script = flags.script
+    // Cookie flags use a `cookie-` prefix so the cookie name does not
+    // collide with the daemon-level `--name <my-browser>` flag the CLI
+    // already consumes for routing.
+    if (flags["cookie-name"]) args.name = flags["cookie-name"]
+    if (flags["cookie-value"] !== undefined) args.value = flags["cookie-value"]
+    if (flags["cookie-domain"]) args.domain = flags["cookie-domain"]
+    if (flags["cookie-path"]) args.path = flags["cookie-path"]
+    if (flags["cookie-secure"] !== undefined) args.secure = flags["cookie-secure"]
+    if (flags["cookie-http-only"] !== undefined) args.httpOnly = flags["cookie-http-only"]
+    if (flags["cookie-expiry"] !== undefined) args.expiry = flags["cookie-expiry"]
+    if (flags["cookie-same-site"]) args.sameSite = flags["cookie-same-site"]
 
     return {args, command: flags.command}
   }

--- a/src/cli.js
+++ b/src/cli.js
@@ -14,6 +14,8 @@ function printHelp() {
   system-testing browser-command [--name my-browser] [--port 1991] --visit=https://example.com
   system-testing browser-command [--name my-browser] --find-by-test-id someID [--timeout 15]
   system-testing browser-command [--name my-browser] --take-screenshot
+  system-testing browser-command [--name my-browser] --command=executeScript --script='return document.title' [--arg ...]
+  system-testing browser-command [--name my-browser] --command=addCookie --cookie-name=auth --cookie-value=... [--cookie-domain=127.0.0.1] [--cookie-path=/]
 `)
 }
 


### PR DESCRIPTION
## Summary

The existing `browser-command-runner` only exposed element-level commands (`visit`, `click`, `interact`, `find`, `findByTestID`, `getHTML`, `getBrowserLogs`, `takeScreenshot`, …). Anything that needed to reach the WebDriver itself — running JS in the page, seeding cookies for an out-of-band sign-in — wasn't possible without patching the runtime, which made automated self-verification of auth-gated flows hard for the CLI consumer.

This adds two narrowly-scoped commands:

- **`executeScript`** — thin wrapper over `WebDriver.executeScript`. Forwards `--arg ...` values as `arguments[i]` in the page; async scripts can `return` a Promise and Selenium awaits it. Useful for verification flows that need to call into application code (e.g. `fetch("/development/sign-in", {credentials: "include", …})`) without driving the UI, or to read browser state the existing finders don't expose.
- **`addCookie`** — wraps `manage().addCookie(...)`. Cookie fields live under a `cookie-` flag prefix (`--cookie-name`, `--cookie-value`, `--cookie-domain`, `--cookie-path`, `--cookie-secure`, `--cookie-http-only`, `--cookie-expiry`, `--cookie-same-site`) so the cookie name never collides with the daemon-level `--name <my-browser>` flag the CLI already consumes for routing.

## Test plan

- [x] `npx jasmine --filter='BrowserCommandRunner|cli helpers'` — 20/20 pass; new specs cover both happy paths and the input-validation rejections (`executeScript requires script`, `addCookie requires name`, `addCookie requires string value`).
- [x] `npm run typecheck`
- [x] `npm run lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)