### PR TITLE
Keep system-test hook enabled after navigation

### DIFF
--- a/spec/use-system-test.spec.js
+++ b/spec/use-system-test.spec.js
@@ -1,0 +1,74 @@
+// @ts-check
+
+import {isSystemTestEnabled, resetSystemTestEnabledForTests} from "../src/use-system-test.js"
+
+const originalLocation = globalThis.location
+const originalSystemTestEnv = process.env.EXPO_PUBLIC_SYSTEM_TEST
+const originalSystemTestHostEnv = process.env.EXPO_PUBLIC_SYSTEM_TEST_HOST
+
+describe("useSystemTest enablement", () => {
+  afterEach(() => {
+    resetSystemTestEnabledForTests()
+    restoreLocation()
+    restoreEnv("EXPO_PUBLIC_SYSTEM_TEST", originalSystemTestEnv)
+    restoreEnv("EXPO_PUBLIC_SYSTEM_TEST_HOST", originalSystemTestHostEnv)
+  })
+
+  it("stays enabled after a system-test URL navigates to a normal route", () => {
+    setLocationHref("http://localhost:5001/blank?systemTest=true")
+
+    expect(isSystemTestEnabled()).toBeTrue()
+
+    setLocationHref("http://localhost:5001/projects/1/edit")
+
+    expect(isSystemTestEnabled()).toBeTrue()
+  })
+
+  it("stays disabled when no system-test URL or environment flag has been seen", () => {
+    setLocationHref("http://localhost:5001/projects/1/edit")
+    delete process.env.EXPO_PUBLIC_SYSTEM_TEST
+    delete process.env.EXPO_PUBLIC_SYSTEM_TEST_HOST
+
+    expect(isSystemTestEnabled()).toBeFalse()
+  })
+})
+
+/**
+ * Sets the global browser location used by the hook auto-detection code.
+ * @param {string} href Browser URL to expose.
+ * @returns {void} Nothing.
+ */
+function setLocationHref(href) {
+  Object.defineProperty(globalThis, "location", {
+    configurable: true,
+    value: {href}
+  })
+}
+
+/** @returns {void} */
+function restoreLocation() {
+  if (originalLocation === undefined) {
+    delete globalThis.location
+    return
+  }
+
+  Object.defineProperty(globalThis, "location", {
+    configurable: true,
+    value: originalLocation
+  })
+}
+
+/**
+ * Restores an environment variable to its original value.
+ * @param {string} key Environment variable name.
+ * @param {string | undefined} value Original value.
+ * @returns {void} Nothing.
+ */
+function restoreEnv(key, value) {
+  if (value === undefined) {
+    delete process.env[key]
+    return
+  }
+
+  process.env[key] = value
+}

--- a/src/use-system-test.js
+++ b/src/use-system-test.js
@@ -3,8 +3,12 @@ import useEventEmitter from "ya-use-event-emitter"
 import SystemTestBrowserHelper from "./system-test-browser-helper.js"
 import {useSystemTestShapeHook} from "./use-system-test-shape-hook.js"
 
+let autoDetectedSystemTestEnabled = false
+
 /** @returns {boolean} */
-function isSystemTestEnabled() {
+export function isSystemTestEnabled() {
+  if (autoDetectedSystemTestEnabled) return true
+
   let enabled = false
   const envEnabled = process.env.EXPO_PUBLIC_SYSTEM_TEST === "true"
   const envHost = process.env.EXPO_PUBLIC_SYSTEM_TEST_HOST
@@ -23,7 +27,14 @@ function isSystemTestEnabled() {
     enabled = true
   }
 
-  return enabled
+  if (enabled) autoDetectedSystemTestEnabled = true
+
+  return autoDetectedSystemTestEnabled
+}
+
+/** @returns {void} */
+export function resetSystemTestEnabledForTests() {
+  autoDetectedSystemTestEnabled = false
 }
 
 /**


### PR DESCRIPTION
## Summary
- keep auto-detected system-test mode sticky after the first systemTest URL/env hit
- cover the route-navigation case where later browser URLs no longer include systemTest=true

## Tests
- npx jasmine spec/use-system-test.spec.js
- npx eslint src/use-system-test.js spec/use-system-test.spec.js
- npm run typecheck