### PR TITLE
Support Android Appium resource id lookups

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,3 +17,5 @@
 - In system tests, if a spec needs to scroll an offscreen element into view, add or use a shared package helper on `Browser`/`SystemTest` (for example `scrollIntoView(...)` / `scrollTestIdIntoView(...)`) instead of project-local DOM query wrappers.
 - For per-example browser cleanup such as auth reset, prefer lifecycle support in `SystemTest.run(...)` / `useSystemTest*` (for example `onTeardown`) over putting destructive cleanup into app bootstrap callbacks like `onInitialize`.
 - If a downstream app exposes a bug rooted in `system-testing`, fix it in `system-testing` first and open the PR here before asking the app repo to carry a dependency override or downstream workaround.
+- Do not run Android emulator/Appium specs locally when `/dev/kvm` is unavailable; they are too slow without hardware virtualization. Use CI/Tensorbuzz for those checks instead, and run non-emulator validation locally.
+- The Android CI setup must install every SDK platform required by the dummy app build. Expo SDK 54 currently builds with compileSdk 36, so keep `platforms;android-36` in `scripts/setup-android-emulator.js` along with the emulator system image packages.

--- a/scripts/setup-android-emulator.js
+++ b/scripts/setup-android-emulator.js
@@ -22,6 +22,7 @@ const extraPackages = process.env.ANDROID_SDK_PACKAGES
 const packages = [
   "platform-tools",
   "platforms;android-33",
+  "platforms;android-36",
   "emulator",
   systemImage,
   ...(ndkVersion ? [`ndk;${ndkVersion}`] : []),

--- a/scripts/setup-android-emulator.js
+++ b/scripts/setup-android-emulator.js
@@ -176,12 +176,15 @@ function runSdkManager(args, {sudo}) {
  * @returns {void}
  */
 function runWithYes(args, {sudo}) {
-  const command = `${sudoPrefix({sudo})} "${sdkmanagerPath}" ${args.join(" ")}`
-  console.log(`[android] yes | ${command}`)
-  const result = spawnSync("bash", ["-lc", `yes | ${command}`], {
+  const fullCommand = sudo ? sudoPrefix({sudo: true}) : sdkmanagerPath
+  const fullArgs = sudo ? buildSudoArgs(sdkmanagerPath, args, sdkEnv()) : args
+
+  console.log(`[android] ${fullCommand} ${fullArgs.join(" ")} < yes`)
+  const result = spawnSync(fullCommand, fullArgs, {
     env: sdkEnv(),
     encoding: "utf-8",
-    stdio: "inherit"
+    input: "y\n".repeat(100),
+    stdio: ["pipe", "inherit", "inherit"]
   })
 
   if (result.status !== 0) {

--- a/spec/appium-driver.spec.js
+++ b/spec/appium-driver.spec.js
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises"
 import os from "node:os"
 import path from "node:path"
-import AppiumDriver, {ensureChromeUserDataDirCapability} from "../src/drivers/appium-driver.js"
+import AppiumDriver, {androidResourceIdSelector, ensureChromeUserDataDirCapability} from "../src/drivers/appium-driver.js"
 
 describe("AppiumDriver", () => {
   it("adds a dedicated user-data-dir for Chrome sessions", async () => {
@@ -49,6 +49,51 @@ describe("AppiumDriver", () => {
     } finally {
       await fs.rm(tempRootDir, {recursive: true, force: true})
     }
+  })
+
+  it("does not add desktop Chrome profile args for Android Chrome sessions", async () => {
+    const tempRootDir = await fs.mkdtemp(path.join(os.tmpdir(), "system-testing-appium-driver-"))
+    const capabilities = {
+      browserName: "Chrome",
+      platformName: "Android"
+    }
+
+    try {
+      const userDataDir = await ensureChromeUserDataDirCapability({
+        browserName: "Chrome",
+        capabilities,
+        tempRootDir
+      })
+
+      expect(userDataDir).toBeUndefined()
+      expect(capabilities["goog:chromeOptions"]).toBeUndefined()
+    } finally {
+      await fs.rm(tempRootDir, {recursive: true, force: true})
+    }
+  })
+
+  it("builds Android resource-id selectors for raw React Native test IDs", () => {
+    expect(androidResourceIdSelector("systemTestingComponent")).toEqual('new UiSelector().resourceIdMatches("(^|.*:id/)systemTestingComponent$")')
+    expect(androidResourceIdSelector("project.board/item[1]")).toEqual('new UiSelector().resourceIdMatches("(^|.*:id/)project\\\\.board/item\\\\[1\\\\]$")')
+  })
+
+  it("uses Android resource-id selectors for native Android app id lookups", () => {
+    const driver = new AppiumDriver({
+      browser: {
+        getSelector: (selector) => selector,
+        throwIfHttpServerError: () => {}
+      },
+      options: {
+        capabilities: {
+          platformName: "Android"
+        }
+      }
+    })
+
+    const locator = driver.idLocator("systemTestingComponent")
+
+    expect(locator.using).toEqual("-android uiautomator")
+    expect(locator.value).toEqual('new UiSelector().resourceIdMatches("(^|.*:id/)systemTestingComponent$")')
   })
 
   it("cleans up the generated Chrome user-data-dir on stop", async () => {

--- a/src/drivers/appium-driver.js
+++ b/src/drivers/appium-driver.js
@@ -16,6 +16,33 @@ function errorWithCause(message, cause) {
 }
 
 /**
+ * Escapes text for use inside a Java regular expression.
+ * @param {string} value Unescaped regex text.
+ * @returns {string} Regex-safe text.
+ */
+function escapeRegExp(value) {
+  return value.replace(/[\\^$.*+?()[\]{}|]/g, "\\$&")
+}
+
+/**
+ * Escapes text for use inside a quoted UiAutomator Java string.
+ * @param {string} value Unescaped Java string text.
+ * @returns {string} Java-string-safe text.
+ */
+function escapeJavaString(value) {
+  return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')
+}
+
+/**
+ * Builds a UiAutomator selector for React Native and package-qualified resource IDs.
+ * @param {string} testId Resource id suffix to match.
+ * @returns {string} UiAutomator selector source.
+ */
+export function androidResourceIdSelector(testId) {
+  return `new UiSelector().resourceIdMatches("(^|.*:id/)${escapeJavaString(escapeRegExp(testId))}$")`
+}
+
+/**
  * Ensures Chrome Appium capabilities use a caller-owned user-data directory.
  * This avoids repeated sessions leaking temp profiles under `/tmp` in CI.
  * @param {object} args
@@ -28,6 +55,12 @@ export async function ensureChromeUserDataDirCapability({browserName, capabiliti
   const resolvedBrowserName = capabilities.browserName ?? browserName
 
   if (typeof resolvedBrowserName !== "string" || resolvedBrowserName.toLowerCase() !== "chrome") {
+    return undefined
+  }
+
+  const platformName = capabilities.platformName
+
+  if (typeof platformName === "string" && platformName.toLowerCase() === "android") {
     return undefined
   }
 
@@ -418,7 +451,7 @@ export default class AppiumDriver extends WebDriverDriver {
     const startTime = Date.now()
     const getTimeLeft = () => Math.max(actualTimeout - (Date.now() - startTime), 0)
     const getElements = async () => {
-      const foundElements = await this.getWebDriver().findElements(By.id(testId))
+      const foundElements = await this.getWebDriver().findElements(this.idLocator(testId))
 
       if (visible !== true && visible !== false) {
         return foundElements
@@ -471,6 +504,30 @@ export default class AppiumDriver extends WebDriverDriver {
     }
 
     return elements
+  }
+
+  /**
+   * Builds an id locator for the active Appium context.
+   * @param {string} testId Test id or native resource id suffix.
+   * @returns {By} Selenium/Appium locator.
+   */
+  idLocator(testId) {
+    if (this.isAndroidNativeAppContext()) {
+      return new By("-android uiautomator", androidResourceIdSelector(testId))
+    }
+
+    return By.id(testId)
+  }
+
+  /**
+   * Checks whether the current session is a native Android app, not Android Chrome.
+   * @returns {boolean} True when UiAutomator resource-id lookup should be used.
+   */
+  isAndroidNativeAppContext() {
+    const platformName = this.options.capabilities?.platformName
+    const browserName = this.options.capabilities?.browserName ?? this.options.browserName
+
+    return typeof platformName === "string" && platformName.toLowerCase() === "android" && !browserName
   }
 
   /**


### PR DESCRIPTION
Summary:
- Skip desktop Chrome profile args for Android Chrome Appium sessions.
- Use UiAutomator resource-id regex lookup for native Android id selectors so React Native raw testID resource IDs are matched.

Validation:
- npx jasmine spec/appium-driver.spec.js
- npm run typecheck
- npm run lint