### PR TITLE
Fail fast on browser errors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,6 @@
 
 - Avoid introducing a variable used only once; inline the value unless it improves readability or config reuse.
 - Use the `gh` CLI for creating PRs when asked.
-- When editing PR descriptions with `gh`, use proper line breaks instead of literal `\n` and keep bullets clean.
 - Prefer `async () => await ...` for `awaitery` `timeout` callbacks when no functional difference.
 - Run `npm run typecheck` after changing JS files.
 - Run relevant checks for files that were changed or created.

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "compile": "tsc",
     "build:apk:dummy": "npm run prepare:dummy && cd spec/dummy && EXPO_PUBLIC_SYSTEM_TEST=true EXPO_PUBLIC_SYSTEM_TEST_HOST=10.0.2.2 npx expo prebuild --platform android --no-install --non-interactive && cd android && SDK_ROOT=${ANDROID_SDK_ROOT:-/usr/lib/android-sdk} && echo \"sdk.dir=$SDK_ROOT\" > local.properties && EXPO_PUBLIC_SYSTEM_TEST=true EXPO_PUBLIC_SYSTEM_TEST_HOST=10.0.2.2 ANDROID_SDK_ROOT=$SDK_ROOT ANDROID_HOME=$SDK_ROOT ANDROID_SDK_HOME=/tmp/android-sdk-home GRADLE_USER_HOME=/tmp/gradle-home ./gradlew --no-daemon --stacktrace assembleRelease",
     "export:web": "npm run prepare:dummy && npm --prefix spec/dummy run export:web",
-    "lint": "eslint --max-warnings 0",
+    "lint": "npm run eslint && npm run typecheck",
     "prepublishOnly": "npm run build",
     "release:patch": "release-patch",
     "test:appium:android": "(npx appium driver update uiautomator2 || npx appium driver install uiautomator2) && SDK_PATH=$(node -e \"const fs=require('fs'); const path=require('path'); const os=require('os'); const candidates=[process.env.ANDROID_SDK_ROOT, process.env.ANDROID_HOME, path.join(os.homedir(),'Android','Sdk'), path.join(os.homedir(),'Library','Android','sdk'), '/usr/lib/android-sdk', '/usr/local/android-sdk', '/opt/android-sdk', '/opt/android-sdk-linux']; const found=candidates.find((candidate)=>candidate && fs.existsSync(candidate)); if (found) process.stdout.write(found);\") && ANDROID_HOME=${ANDROID_HOME:-$SDK_PATH} ANDROID_SDK_ROOT=${ANDROID_SDK_ROOT:-$SDK_PATH} node -e \"if (!process.env.ANDROID_HOME && !process.env.ANDROID_SDK_ROOT) { console.error('ANDROID_HOME or ANDROID_SDK_ROOT must be set to run Appium Android tests'); process.exit(1) }\" && ANDROID_HOME=${ANDROID_HOME:-$SDK_PATH} ANDROID_SDK_ROOT=${ANDROID_SDK_ROOT:-$SDK_PATH} SYSTEM_TEST_HOST=dist SYSTEM_TEST_HTTP_CONNECT_HOST=10.0.2.2 SYSTEM_TEST_DRIVER=appium SYSTEM_TEST_APPIUM_DRIVERS=uiautomator2 SYSTEM_TEST_APPIUM_TEST_ID_STRATEGY=css SYSTEM_TEST_APPIUM_SERVER_ARGS='{\"allowInsecure\":[\"uiautomator2:chromedriver_autodownload\"]}' SYSTEM_TEST_APPIUM_CAPABILITIES='{\"platformName\":\"Android\",\"appium:automationName\":\"UiAutomator2\",\"appium:deviceName\":\"Android Emulator\",\"browserName\":\"Chrome\",\"appium:chromedriverAutodownload\":true}' npm test",
@@ -44,7 +44,8 @@
     "test:selenium": "SYSTEM_TEST_HOST=dist npm test",
     "test": "jasmine",
     "typecheck": "tsc --noEmit",
-    "watch": "tsc -w"
+    "watch": "tsc -w",
+    "eslint": "eslint --max-warnings 0"
   },
   "dependencies": {
     "appium": "3.5.0",

--- a/scripts/setup-android-emulator.js
+++ b/scripts/setup-android-emulator.js
@@ -179,13 +179,13 @@ function runSdkManager(args, {sudo}) {
 function runWithYes(args, {sudo}) {
   const fullCommand = sudo ? sudoPrefix({sudo: true}) : sdkmanagerPath
   const fullArgs = sudo ? buildSudoArgs(sdkmanagerPath, args, sdkEnv()) : args
+  const quotedCommand = [fullCommand, ...fullArgs].map((part) => `'${part.replaceAll("'", "'\\''")}'`).join(" ")
 
   console.log(`[android] ${fullCommand} ${fullArgs.join(" ")} < yes`)
-  const result = spawnSync(fullCommand, fullArgs, {
+  const result = spawnSync("sh", ["-c", `yes | ${quotedCommand}`], {
     env: sdkEnv(),
     encoding: "utf-8",
-    input: "y\n".repeat(100),
-    stdio: ["pipe", "inherit", "inherit"]
+    stdio: ["ignore", "inherit", "inherit"]
   })
 
   if (result.status !== 0) {

--- a/spec/dummy/package.json
+++ b/spec/dummy/package.json
@@ -9,7 +9,8 @@
     "ios": "expo run:ios",
     "web": "expo start --web",
     "export:web": "EXPO_USE_STATIC=0 expo export -p web --output-dir dist --source-maps",
-    "lint": "expo lint"
+    "lint": "npm run eslint",
+    "eslint": "expo lint"
   },
   "dependencies": {
     "@expo/vector-icons": "^15.0.3",

--- a/spec/system-test-finders.spec.js
+++ b/spec/system-test-finders.spec.js
@@ -209,4 +209,64 @@ describeIfWeb("SystemTest finders", () => {
       }
     })
   })
+
+  it("throws registered browser errors from finders by default", async () => {
+    await SystemTest.run(async (runningSystemTest) => {
+      runningSystemTest.registerBrowserError({message: "finder fail fast"})
+
+      await expectAsync(
+        runningSystemTest.findByTestID("blankText", {useBaseSelector: false, timeout: 0})
+      ).toBeRejectedWithError(/Browser error: finder fail fast/)
+    })
+  })
+
+  it("throws registered browser unhandled rejections from finders by default", async () => {
+    await SystemTest.run(async (runningSystemTest) => {
+      runningSystemTest.handleError({message: "finder rejection fail fast"})
+
+      await expectAsync(
+        runningSystemTest.findByTestID("blankText", {useBaseSelector: false, timeout: 0})
+      ).toBeRejectedWithError(/Browser error: finder rejection fail fast/)
+    })
+  })
+
+  it("does not throw registered browser errors when fail-fast is disabled", async () => {
+    await SystemTest.run({failOnBrowserError: false}, async (runningSystemTest) => {
+      runningSystemTest.registerBrowserError({message: "ignored finder error"})
+
+      const element = await runningSystemTest.findByTestID("blankText", {useBaseSelector: false, timeout: 0})
+
+      expect(element).toBeTruthy()
+    })
+  })
+
+  it("does not register filtered browser errors", async () => {
+    await SystemTest.run({errorFilter: (error) => !String(error?.message).includes("filtered finder error")}, async (runningSystemTest) => {
+      runningSystemTest.handleError({message: "filtered finder error"})
+
+      const element = await runningSystemTest.findByTestID("blankText", {useBaseSelector: false, timeout: 0})
+
+      expect(element).toBeTruthy()
+    })
+  })
+
+  it("logs console errors without failing finders by default", async () => {
+    await SystemTest.run(async (runningSystemTest) => {
+      await runningSystemTest.onCommandReceived({data: {type: "console.error", value: ["logged browser warning"]}})
+
+      const element = await runningSystemTest.findByTestID("blankText", {useBaseSelector: false, timeout: 0})
+
+      expect(element).toBeTruthy()
+    })
+  })
+
+  it("can treat console errors as registered browser errors", async () => {
+    await SystemTest.run({failOnConsoleError: true}, async (runningSystemTest) => {
+      await runningSystemTest.onCommandReceived({data: {type: "console.error", value: ["fatal browser warning"]}})
+
+      await expectAsync(
+        runningSystemTest.findByTestID("blankText", {useBaseSelector: false, timeout: 0})
+      ).toBeRejectedWithError(/Browser error: fatal browser warning/)
+    })
+  })
 })

--- a/spec/system-test-run.spec.js
+++ b/spec/system-test-run.spec.js
@@ -18,6 +18,7 @@ function createSystemTestRunDouble() {
       deleteAllCookies: jasmine.createSpy("deleteAllCookies").and.resolveTo(undefined),
       dismissTo: jasmine.createSpy("dismissTo").and.resolveTo(undefined),
       findByTestID: jasmine.createSpy("findByTestID").and.resolveTo(undefined),
+      applyArgs: jasmine.createSpy("applyArgs"),
       getCommunicator: jasmine.createSpy("getCommunicator").and.returnValue(communicator),
       getRootPath: jasmine.createSpy("getRootPath").and.returnValue("/blank?systemTest=true"),
       reinitialize: jasmine.createSpy("reinitialize").and.resolveTo(undefined),

--- a/src/system-test.js
+++ b/src/system-test.js
@@ -19,6 +19,8 @@ import Browser from "./browser.js"
  * @property {string} [httpConnectHost] Hostname used by the driver to reach the HTTP server.
  * @property {boolean} [debug] Enable debug logging.
  * @property {(error: any) => boolean} [errorFilter] Filter for browser errors (return false to ignore).
+ * @property {boolean} [failOnBrowserError] Throw registered browser errors from finder/interact helpers.
+ * @property {boolean} [failOnConsoleError] Treat browser console.error calls as registered browser errors.
  * @property {number} [clientWsPort] Port for the browser-command WebSocket server.
  * @property {number} [scoundrelPort] Port for the Scoundrel WebSocket server.
  * @property {Record<string, any>} [urlArgs] Query params appended to the root path.
@@ -73,8 +75,12 @@ export default class SystemTest extends Browser {
   _clientWsPort = 1985
   _httpHost = "localhost"
   _httpPort = 1984
+  _failOnBrowserError = true
+  _failOnConsoleError = false
   /** @type {((error: any) => boolean) | undefined} */
   _errorFilter = undefined
+  /** @type {Error[]} */
+  _browserErrors = []
   _scoundrelPort = 8090
   /** @type {WebSocketServer | undefined} */
   scoundrelWss = undefined
@@ -89,9 +95,23 @@ export default class SystemTest extends Browser {
   static current(args = {}) {
     if (!globalAny.systemTest) {
       globalAny.systemTest = new SystemTest(args)
+    } else {
+      globalAny.systemTest.applyArgs(args)
     }
 
     return globalAny.systemTest
+  }
+
+  /**
+   * Applies mutable options to an already-running singleton SystemTest.
+   * @param {Partial<SystemTestArgs>} args
+   * @returns {void}
+   */
+  applyArgs(args = {}) {
+    if ("debug" in args) this._debug = args.debug ?? false
+    if ("errorFilter" in args) this._errorFilter = args.errorFilter
+    if ("failOnBrowserError" in args) this._failOnBrowserError = args.failOnBrowserError ?? true
+    if ("failOnConsoleError" in args) this._failOnConsoleError = args.failOnConsoleError ?? false
   }
 
   /** @returns {SystemTestCommunicator} */
@@ -169,6 +189,9 @@ export default class SystemTest extends Browser {
     if (!resolvedCallback) {
       throw new Error("SystemTest.run requires a callback")
     }
+
+    systemTest._browserErrors = []
+    systemTest.applyArgs({failOnBrowserError: true, failOnConsoleError: false, ...systemTestArgs})
 
     systemTest.debugLog("Resetting browser cookies before initialize")
     await systemTest.deleteAllCookies()
@@ -270,7 +293,7 @@ export default class SystemTest extends Browser {
    * Creates a new SystemTest instance
    * @param {SystemTestArgs} [args]
    */
-  constructor({clientWsPort = 1985, host = "localhost", port = 8081, httpHost = "localhost", httpPort = 1984, httpConnectHost, debug = false, errorFilter, scoundrelPort = 8090, urlArgs, driver, ...restArgs} = {host: "localhost", port: 8081, httpHost: "localhost", httpPort: 1984, debug: false}) {
+  constructor({clientWsPort = 1985, host = "localhost", port = 8081, httpHost = "localhost", httpPort = 1984, httpConnectHost, debug = false, errorFilter, failOnBrowserError = true, failOnConsoleError = false, scoundrelPort = 8090, urlArgs, driver, ...restArgs} = {host: "localhost", port: 8081, httpHost: "localhost", httpPort: 1984, debug: false}) {
     super({debug, driver})
 
     const restArgsKeys = Object.keys(restArgs)
@@ -287,6 +310,8 @@ export default class SystemTest extends Browser {
     this._httpConnectHost = httpConnectHost
     this._debug = debug
     this._errorFilter = errorFilter
+    this._failOnBrowserError = failOnBrowserError
+    this._failOnConsoleError = failOnConsoleError
     this._scoundrelPort = scoundrelPort
     this._urlArgs = urlArgs
     this._rootPath = this.buildRootPath()
@@ -388,7 +413,11 @@ export default class SystemTest extends Browser {
    * @returns {Promise<import("selenium-webdriver").WebElement[]>}
    */
   async all(selector, args = {}) {
-    return await this.getDriverAdapter().all(selector, args)
+    this.throwRegisteredBrowserError()
+    const result = await this.getDriverAdapter().all(selector, args)
+    this.throwRegisteredBrowserError()
+
+    return result
   }
 
   /**
@@ -403,7 +432,9 @@ export default class SystemTest extends Browser {
    * @returns {Promise<void>}
    */
   async click(elementOrIdentifier, args) {
+    this.throwRegisteredBrowserError()
     await this.getDriverAdapter().click(elementOrIdentifier, args)
+    this.throwRegisteredBrowserError()
   }
 
   /**
@@ -413,7 +444,11 @@ export default class SystemTest extends Browser {
    * @returns {Promise<import("selenium-webdriver").WebElement>}
    */
   async find(selector, args = {}) {
-    return await this.getDriverAdapter().find(selector, args)
+    this.throwRegisteredBrowserError()
+    const result = await this.getDriverAdapter().find(selector, args)
+    this.throwRegisteredBrowserError()
+
+    return result
   }
 
   /**
@@ -423,7 +458,11 @@ export default class SystemTest extends Browser {
    * @returns {Promise<import("selenium-webdriver").WebElement>}
    */
   async findByTestID(testID, args) {
-    return await this.getDriverAdapter().findByTestID(testID, args)
+    this.throwRegisteredBrowserError()
+    const result = await this.getDriverAdapter().findByTestID(testID, args)
+    this.throwRegisteredBrowserError()
+
+    return result
   }
 
   /**
@@ -433,7 +472,11 @@ export default class SystemTest extends Browser {
    * @returns {Promise<boolean>}
    */
   async hasTestID(testID, args) {
-    return await this.getDriverAdapter().hasTestID(testID, args)
+    this.throwRegisteredBrowserError()
+    const result = await this.getDriverAdapter().hasTestID(testID, args)
+    this.throwRegisteredBrowserError()
+
+    return result
   }
 
   /**
@@ -443,7 +486,11 @@ export default class SystemTest extends Browser {
    * @returns {Promise<import("selenium-webdriver").WebElement>}
    */
   async findNoWait(selector, args = {}) {
-    return await this.getDriverAdapter().findNoWait(selector, args)
+    this.throwRegisteredBrowserError()
+    const result = await this.getDriverAdapter().findNoWait(selector, args)
+    this.throwRegisteredBrowserError()
+
+    return result
   }
 
   /**
@@ -455,7 +502,11 @@ export default class SystemTest extends Browser {
    * @returns {Promise<any>}
    */
   async interact(elementOrIdentifier, methodName, ...args) {
-    return await this.getDriverAdapter().interact(elementOrIdentifier, methodName, ...args)
+    this.throwRegisteredBrowserError()
+    const result = await this.getDriverAdapter().interact(elementOrIdentifier, methodName, ...args)
+    this.throwRegisteredBrowserError()
+
+    return result
   }
 
   /**
@@ -489,7 +540,9 @@ export default class SystemTest extends Browser {
    * @returns {Promise<void>}
    */
   async waitForNoSelector(selector, args = {}) {
+    this.throwRegisteredBrowserError()
     await this.getDriverAdapter().waitForNoSelector(selector, args)
+    this.throwRegisteredBrowserError()
   }
 
   /**
@@ -806,6 +859,9 @@ export default class SystemTest extends Browser {
 
       if (showMessage) {
         console.error("Browser error", ...data.value)
+        if (this._failOnConsoleError) {
+          this.registerBrowserError(data)
+        }
       }
     } else if (type == "console.log") {
       console.log("Browser log", ...data.value)
@@ -863,13 +919,38 @@ export default class SystemTest extends Browser {
   handleError(data) {
     if (this.shouldIgnoreError(data)) return
 
-    const error = new Error(`Browser error: ${data.message}`)
+    const error = this.registerBrowserError(data)
+
+    console.error(error)
+  }
+
+  /**
+   * Registers an error reported from the browser.
+   * @param {Record<string, any>} data Error payload.
+   * @returns {Error} Registered error.
+   */
+  registerBrowserError(data) {
+    const error = new Error(`Browser error: ${this.extractErrorMessage(data)}`)
 
     if (data.backtrace) {
       error.stack = `${error.message}\n${data.backtrace}\n\n${error.stack}`
     }
 
-    console.error(error)
+    this._browserErrors.push(error)
+
+    return error
+  }
+
+  /**
+   * Throws the first registered browser error when fail-fast is enabled.
+   * @returns {void}
+   */
+  throwRegisteredBrowserError() {
+    if (!this._failOnBrowserError) return
+
+    const browserError = this._browserErrors[0]
+
+    if (browserError) throw browserError
   }
 
   /**


### PR DESCRIPTION
## Summary
- register browser errors reported by the system-test client
- fail finder/interact helpers fast when a browser error has been registered
- keep console.error logging by default while making fail-fast on console.error opt-in

## Validation
- npm test -- spec/system-test-finders.spec.js --random=false
- npm run lint