### PR TITLE
Add browser text and exists helpers

### DIFF
--- a/spec/browser.spec.js
+++ b/spec/browser.spec.js
@@ -115,6 +115,42 @@ describe("Browser", () => {
     await browser.expectTestIDCssColor("panel", "background-color", "30, 41, 59", "255, 255, 255", "panel")
   })
 
+  it("reads visible text through the driver adapter", async () => {
+    const browser = new Browser()
+    const textCalls = []
+
+    browser.driverAdapter = /** @type {any} */ ({
+      text: async (selector, args) => {
+        textCalls.push([selector, args])
+
+        return "Visible text"
+      }
+    })
+
+    expect(await browser.text("body", {visible: null})).toEqual("Visible text")
+    expect(textCalls).toEqual([["body", {visible: null}]])
+  })
+
+  it("checks selector existence through the driver adapter", async () => {
+    const browser = new Browser()
+    const existsCalls = []
+
+    browser.driverAdapter = /** @type {any} */ ({
+      exists: async (selector, args) => {
+        existsCalls.push([selector, args])
+
+        return selector === "#present"
+      }
+    })
+
+    expect(await browser.exists("#present", {timeout: 0})).toEqual(true)
+    expect(await browser.exists("#missing", {timeout: 0})).toEqual(false)
+    expect(existsCalls).toEqual([
+      ["#present", {timeout: 0}],
+      ["#missing", {timeout: 0}]
+    ])
+  })
+
   it("rejects CSS color substring matches by test id", async () => {
     const browser = new Browser()
 

--- a/spec/system-test-finders.spec.js
+++ b/spec/system-test-finders.spec.js
@@ -188,6 +188,110 @@ describeIfWeb("SystemTest finders", () => {
     })
   })
 
+  it("exists returns false when a default-timeout selector lookup times out", async () => {
+    await SystemTest.run(async (runningSystemTest) => {
+      const originalTimeouts = runningSystemTest.getTimeouts()
+
+      try {
+        await runningSystemTest.setTimeouts(100)
+
+        const result = await runningSystemTest.exists("#does-not-exist", {useBaseSelector: false})
+
+        expect(result).toBe(false)
+      } finally {
+        await runningSystemTest.setTimeouts(originalTimeouts)
+      }
+    })
+  })
+
+  it("checks registered browser errors before and after exists", async () => {
+    await SystemTest.run(async (runningSystemTest) => {
+      const driverAdapter = runningSystemTest.getDriverAdapter()
+      const originalExists = driverAdapter.exists.bind(driverAdapter)
+      let existsCalls = 0
+
+      driverAdapter.exists = async () => {
+        existsCalls += 1
+
+        return true
+      }
+      runningSystemTest.registerBrowserError({message: "exists fail fast"})
+
+      try {
+        await expectAsync(
+          runningSystemTest.exists("[data-testid='blankText']", {useBaseSelector: false, timeout: 0})
+        ).toBeRejectedWithError(/Browser error: exists fail fast/)
+
+        expect(existsCalls).toEqual(0)
+      } finally {
+        driverAdapter.exists = originalExists
+      }
+    })
+
+    await SystemTest.run(async (runningSystemTest) => {
+      const driverAdapter = runningSystemTest.getDriverAdapter()
+      const originalExists = driverAdapter.exists.bind(driverAdapter)
+
+      driverAdapter.exists = async () => {
+        runningSystemTest.registerBrowserError({message: "exists fail after adapter"})
+
+        return true
+      }
+
+      try {
+        await expectAsync(
+          runningSystemTest.exists("[data-testid='blankText']", {useBaseSelector: false, timeout: 0})
+        ).toBeRejectedWithError(/Browser error: exists fail after adapter/)
+      } finally {
+        driverAdapter.exists = originalExists
+      }
+    })
+  })
+
+  it("checks registered browser errors before and after text", async () => {
+    await SystemTest.run(async (runningSystemTest) => {
+      const driverAdapter = runningSystemTest.getDriverAdapter()
+      const originalText = driverAdapter.text.bind(driverAdapter)
+      let textCalls = 0
+
+      driverAdapter.text = async () => {
+        textCalls += 1
+
+        return "Blank"
+      }
+      runningSystemTest.registerBrowserError({message: "text fail fast"})
+
+      try {
+        await expectAsync(
+          runningSystemTest.text("[data-testid='blankText']", {useBaseSelector: false, timeout: 0})
+        ).toBeRejectedWithError(/Browser error: text fail fast/)
+
+        expect(textCalls).toEqual(0)
+      } finally {
+        driverAdapter.text = originalText
+      }
+    })
+
+    await SystemTest.run(async (runningSystemTest) => {
+      const driverAdapter = runningSystemTest.getDriverAdapter()
+      const originalText = driverAdapter.text.bind(driverAdapter)
+
+      driverAdapter.text = async () => {
+        runningSystemTest.registerBrowserError({message: "text fail after adapter"})
+
+        return "Blank"
+      }
+
+      try {
+        await expectAsync(
+          runningSystemTest.text("[data-testid='blankText']", {useBaseSelector: false, timeout: 0})
+        ).toBeRejectedWithError(/Browser error: text fail after adapter/)
+      } finally {
+        driverAdapter.text = originalText
+      }
+    })
+  })
+
   it("can scroll found elements into view before returning them", async () => {
     await SystemTest.run(async (runningSystemTest) => {
       const driverAdapter = runningSystemTest.getDriverAdapter()

--- a/src/browser.js
+++ b/src/browser.js
@@ -342,6 +342,15 @@ export default class Browser {
   /**
    * @param {string} selector
    * @param {import("./system-test.js").FindArgs} [args]
+   * @returns {Promise<boolean>}
+   */
+  async exists(selector, args = {}) {
+    return await this.getDriverAdapter().exists(selector, args)
+  }
+
+  /**
+   * @param {string} selector
+   * @param {import("./system-test.js").FindArgs} [args]
    * @returns {Promise<import("selenium-webdriver").WebElement>}
    */
   async find(selector, args = {}) {
@@ -374,6 +383,15 @@ export default class Browser {
    */
   async findNoWait(selector, args = {}) {
     return await this.getDriverAdapter().findNoWait(selector, args)
+  }
+
+  /**
+   * @param {string} selector
+   * @param {import("./system-test.js").FindArgs} [args]
+   * @returns {Promise<string>}
+   */
+  async text(selector, args = {}) {
+    return await this.getDriverAdapter().text(selector, args)
   }
 
   /**

--- a/src/drivers/webdriver-driver.js
+++ b/src/drivers/webdriver-driver.js
@@ -516,7 +516,13 @@ export default class WebDriverDriver {
    * @returns {Promise<boolean>}
    */
   async exists(selector, args = {}) {
-    return (await this.all(selector, args)).length > 0
+    try {
+      return (await this.all(selector, args)).length > 0
+    } catch (error) {
+      if (isElementLookupTimeoutError(error)) return false
+
+      throw error
+    }
   }
 
   /**

--- a/src/drivers/webdriver-driver.js
+++ b/src/drivers/webdriver-driver.js
@@ -511,6 +511,15 @@ export default class WebDriverDriver {
   }
 
   /**
+   * @param {string} selector
+   * @param {FindArgs} [args]
+   * @returns {Promise<boolean>}
+   */
+  async exists(selector, args = {}) {
+    return (await this.all(selector, args)).length > 0
+  }
+
+  /**
    * Finds a single element by CSS selector
    * @param {string} selector
    * @param {FindArgs} [args]
@@ -541,6 +550,15 @@ export default class WebDriverDriver {
     }
 
     return elements[0]
+  }
+
+  /**
+   * @param {string} selector
+   * @param {FindArgs} [args]
+   * @returns {Promise<string>}
+   */
+  async text(selector, args = {}) {
+    return await (await this.find(selector, args)).getText()
   }
 
   /**

--- a/src/system-test.js
+++ b/src/system-test.js
@@ -433,6 +433,34 @@ export default class SystemTest extends Browser {
   }
 
   /**
+   * Checks whether a CSS selector matches an element.
+   * @param {string} selector
+   * @param {FindArgs} [args]
+   * @returns {Promise<boolean>}
+   */
+  async exists(selector, args = {}) {
+    this.throwRegisteredBrowserError()
+    const result = await this.getDriverAdapter().exists(selector, args)
+    this.throwRegisteredBrowserError()
+
+    return result
+  }
+
+  /**
+   * Reads visible text from a CSS selector.
+   * @param {string} selector
+   * @param {FindArgs} [args]
+   * @returns {Promise<string>}
+   */
+  async text(selector, args = {}) {
+    this.throwRegisteredBrowserError()
+    const result = await this.getDriverAdapter().text(selector, args)
+    this.throwRegisteredBrowserError()
+
+    return result
+  }
+
+  /**
    * Clicks an element that has children which fills out the element and would otherwise have caused a ElementClickInterceptedError
    * @param {string|import("selenium-webdriver").WebElement} elementOrIdentifier
    * @returns {Promise<void>}


### PR DESCRIPTION
## Summary
- add Browser.text and Browser.exists helpers
- delegate helper behavior through the WebDriver driver adapter
- cover helper delegation in browser specs

## Validation
- npx jasmine spec/browser.spec.js
- npm run typecheck
- npm run build
- npm run lint