### PR TITLE
Use touch actions for Appium native scroll fallback

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "prepare:dummy": "npm run build && rm -rf spec/dummy/node_modules/system-testing && mkdir -p spec/dummy/node_modules/system-testing && cp -r build package.json spec/dummy/node_modules/system-testing/",
     "build": "rm -rf build && npm run compile",
     "compile": "tsc",
-    "build:apk:dummy": "npm run prepare:dummy && cd spec/dummy && EXPO_PUBLIC_SYSTEM_TEST=true EXPO_PUBLIC_SYSTEM_TEST_HOST=10.0.2.2 npx expo prebuild --platform android --no-install --non-interactive && cd android && SDK_ROOT=${ANDROID_SDK_ROOT:-/usr/lib/android-sdk} && echo \"sdk.dir=$SDK_ROOT\" > local.properties && EXPO_PUBLIC_SYSTEM_TEST=true EXPO_PUBLIC_SYSTEM_TEST_HOST=10.0.2.2 ANDROID_SDK_ROOT=$SDK_ROOT ANDROID_HOME=$SDK_ROOT ANDROID_SDK_HOME=/tmp/android-sdk-home GRADLE_USER_HOME=/tmp/gradle-home ./gradlew --no-daemon --stacktrace assembleRelease",
+    "build:apk:dummy": "npm run prepare:dummy && cd spec/dummy && EXPO_PUBLIC_SYSTEM_TEST=true EXPO_PUBLIC_SYSTEM_TEST_HOST=10.0.2.2 npx expo prebuild --platform android --no-install --non-interactive && node ../../scripts/set-gradle-wrapper-network-timeout.mjs android/gradle/wrapper/gradle-wrapper.properties 60000 && cd android && SDK_ROOT=${ANDROID_SDK_ROOT:-/usr/lib/android-sdk} && echo \"sdk.dir=$SDK_ROOT\" > local.properties && EXPO_PUBLIC_SYSTEM_TEST=true EXPO_PUBLIC_SYSTEM_TEST_HOST=10.0.2.2 ANDROID_SDK_ROOT=$SDK_ROOT ANDROID_HOME=$SDK_ROOT ANDROID_SDK_HOME=/tmp/android-sdk-home GRADLE_USER_HOME=/tmp/gradle-home ./gradlew --no-daemon --stacktrace assembleRelease",
     "export:web": "npm run prepare:dummy && npm --prefix spec/dummy run export:web",
     "lint": "npm run eslint && npm run typecheck",
     "prepublishOnly": "npm run build",

--- a/scripts/set-gradle-wrapper-network-timeout.mjs
+++ b/scripts/set-gradle-wrapper-network-timeout.mjs
@@ -1,0 +1,18 @@
+import fs from "node:fs"
+
+const [propertiesPath, timeoutMs] = process.argv.slice(2)
+
+if (!propertiesPath) {
+  throw new Error("Usage: set-gradle-wrapper-network-timeout.mjs <gradle-wrapper.properties> <timeout-ms>")
+}
+if (!timeoutMs || !/^[1-9]\d*$/.test(timeoutMs)) {
+  throw new Error(`Expected timeout-ms to be a positive integer, got: ${String(timeoutMs)}`)
+}
+
+const originalProperties = fs.readFileSync(propertiesPath, "utf8")
+const timeoutLine = `networkTimeout=${timeoutMs}`
+const nextProperties = originalProperties.match(/^networkTimeout=/m)
+  ? originalProperties.replace(/^networkTimeout=.*/m, timeoutLine)
+  : `${originalProperties.replace(/\s*$/, "\n")}${timeoutLine}\n`
+
+fs.writeFileSync(propertiesPath, nextProperties)

--- a/spec/appium-driver.spec.js
+++ b/spec/appium-driver.spec.js
@@ -182,6 +182,105 @@ describe("AppiumDriver", () => {
     expect(setTimeouts.calls.allArgs()).toEqual([[{implicit: 0}], [{implicit: 5000}]])
   })
 
+  it("searches upward when a native id is above the retained viewport offset", async () => {
+    const element = {getId: async () => "native-id-element"}
+    const targetSelector = androidResourceIdSelector("userShowScreen/email/row")
+    const driver = new AppiumDriver({
+      browser: {
+        driver: undefined,
+        getSelector: (selector) => selector,
+        throwIfHttpServerError: () => {}
+      },
+      options: {
+        capabilities: {
+          platformName: "Android"
+        }
+      }
+    })
+    const scrollDirections = []
+    let scrolledUp = false
+    const findElements = jasmine.createSpy("findElements").and.callFake(async (locator) => {
+      if (locator.value === targetSelector) return scrolledUp ? [element] : []
+
+      return []
+    })
+
+    driver.setWebDriver(/** @type {import("selenium-webdriver").WebDriver} */ ({
+      executeScript: jasmine.createSpy("executeScript").and.callFake(async (script, args) => {
+        if (script !== "mobile: scrollGesture") return undefined
+
+        scrollDirections.push(args.direction)
+        if (args.direction === "up") scrolledUp = true
+        return true
+      }),
+      findElements,
+      manage: () => ({
+        getTimeouts: async () => ({implicit: 5000}),
+        setTimeouts: async () => {},
+        window: () => ({
+          getRect: async () => ({x: 0, y: 0, width: 400, height: 800})
+        })
+      })
+    }))
+
+    await expectAsync(driver.findById("userShowScreen/email/row", {
+      scrollTo: true,
+      timeout: 0
+    })).toBeResolvedTo(element)
+
+    expect(scrollDirections).toEqual(["up"])
+  })
+
+  it("continues downward after upward native viewport scanning misses", async () => {
+    const element = {getId: async () => "native-id-element"}
+    const targetSelector = androidResourceIdSelector("organizationShowScreen/project-1/title")
+    const driver = new AppiumDriver({
+      browser: {
+        driver: undefined,
+        getSelector: (selector) => selector,
+        throwIfHttpServerError: () => {}
+      },
+      options: {
+        capabilities: {
+          platformName: "Android"
+        }
+      }
+    })
+    const scrollDirections = []
+    let downScrolls = 0
+    const findElements = jasmine.createSpy("findElements").and.callFake(async (locator) => {
+      if (locator.value === targetSelector) return downScrolls >= 2 ? [element] : []
+
+      return []
+    })
+
+    driver.setWebDriver(/** @type {import("selenium-webdriver").WebDriver} */ ({
+      executeScript: jasmine.createSpy("executeScript").and.callFake(async (script, args) => {
+        if (script !== "mobile: scrollGesture") return undefined
+
+        scrollDirections.push(args.direction)
+        if (args.direction === "down") downScrolls += 1
+        return true
+      }),
+      findElements,
+      manage: () => ({
+        getTimeouts: async () => ({implicit: 5000}),
+        setTimeouts: async () => {},
+        window: () => ({
+          getRect: async () => ({x: 0, y: 0, width: 400, height: 800})
+        })
+      })
+    }))
+
+    await expectAsync(driver.findById("organizationShowScreen/project-1/title", {
+      scrollTo: true,
+      timeout: 0
+    })).toBeResolvedTo(element)
+
+    expect(scrollDirections).toContain("up")
+    expect(scrollDirections.filter((direction) => direction === "down").length).toEqual(2)
+  })
+
   it("falls back to W3C actions when native mobile scroll gestures are unsupported", async () => {
     let actionsCommand
     const execute = jasmine.createSpy("execute").and.callFake(async (command) => {

--- a/spec/appium-driver.spec.js
+++ b/spec/appium-driver.spec.js
@@ -135,6 +135,41 @@ describe("AppiumDriver", () => {
     expect(setTimeouts.calls.allArgs()).toEqual([[{implicit: 0}], [{implicit: 5000}]])
   })
 
+  it("waits for native text scoped to a test id", async () => {
+    const element = {getId: async () => "native-test-id-text-element"}
+    const driver = new AppiumDriver({
+      browser: {
+        driver: undefined,
+        getSelector: (selector) => selector,
+        throwIfHttpServerError: () => {}
+      },
+      options: {
+        capabilities: {
+          platformName: "Android"
+        }
+      }
+    })
+    const setTimeouts = jasmine.createSpy("setTimeouts").and.resolveTo()
+    const findElements = jasmine.createSpy("findElements").and.callFake(async (locator) => {
+      if (locator.value === 'new UiSelector().resourceIdMatches("(^|.*:id/)userShowScreen/email/row$").childSelector(new UiSelector().textContains("native@example.com"))') {
+        return [element]
+      }
+
+      return []
+    })
+
+    driver.setWebDriver(/** @type {import("selenium-webdriver").WebDriver} */ ({
+      findElements,
+      manage: () => ({
+        getTimeouts: async () => ({implicit: 5000}),
+        setTimeouts
+      })
+    }))
+
+    await expectAsync(driver.waitForTestIDText("userShowScreen/email/row", "native@example.com", {timeout: 0})).toBeResolved()
+    expect(setTimeouts.calls.allArgs()).toEqual([[{implicit: 0}], [{implicit: 5000}]])
+  })
+
   it("scrolls native id lookups with caller-provided scroll containers", async () => {
     const element = {getId: async () => "native-id-element"}
     const targetSelector = androidResourceIdSelector("projectShowScreen/editButton")
@@ -277,7 +312,7 @@ describe("AppiumDriver", () => {
       timeout: 0
     })).toBeResolvedTo(element)
 
-    expect(scrollDirections).toContain("up")
+    expect(scrollDirections.slice(0, 4)).toEqual(["up", "down", "up", "down"])
     expect(scrollDirections.filter((direction) => direction === "down").length).toEqual(2)
   })
 

--- a/spec/appium-driver.spec.js
+++ b/spec/appium-driver.spec.js
@@ -183,12 +183,10 @@ describe("AppiumDriver", () => {
   })
 
   it("falls back to W3C actions when native mobile scroll gestures are unsupported", async () => {
-    const actionChain = {
-      move: jasmine.createSpy("move").and.callFake(() => actionChain),
-      press: jasmine.createSpy("press").and.callFake(() => actionChain),
-      release: jasmine.createSpy("release").and.callFake(() => actionChain),
-      perform: jasmine.createSpy("perform").and.resolveTo()
-    }
+    let actionsCommand
+    const execute = jasmine.createSpy("execute").and.callFake(async (command) => {
+      actionsCommand = command
+    })
     const driver = new AppiumDriver({
       browser: {
         driver: undefined,
@@ -203,7 +201,7 @@ describe("AppiumDriver", () => {
     })
 
     driver.setWebDriver(/** @type {import("selenium-webdriver").WebDriver} */ ({
-      actions: () => actionChain,
+      execute,
       executeScript: jasmine.createSpy("executeScript").and.rejectWith(new Error("Unknown mobile command")),
       findElements: jasmine.createSpy("findElements").and.resolveTo([]),
       manage: () => ({
@@ -216,7 +214,11 @@ describe("AppiumDriver", () => {
     }))
 
     await expectAsync(driver.findByNativeText("Missing text", {timeout: 0})).toBeRejectedWithError(/Element couldn't be found/)
-    expect(actionChain.perform).toHaveBeenCalled()
+    if (!actionsCommand) throw new Error("Expected W3C actions command")
+    const pointerAction = actionsCommand.getParameter("actions")[0]
+
+    expect(pointerAction.parameters.pointerType).toEqual("touch")
+    expect(pointerAction.actions.map((action) => action.type)).toEqual(["pointerMove", "pointerDown", "pointerMove", "pointerUp"])
   })
 
   it("cleans up the generated Chrome user-data-dir on stop", async () => {

--- a/spec/browser.spec.js
+++ b/spec/browser.spec.js
@@ -74,14 +74,16 @@ describe("Browser", () => {
   it("waits for text on elements by test id", async () => {
     const browser = new Browser()
     const findArgs = []
+    const waitForTextCalls = []
     const texts = [
-      "Loading",
-      "Ready",
       "Removing stale text",
       "Fresh text"
     ]
 
     browser.driverAdapter = /** @type {any} */ ({
+      waitForTestIDText: async (testID, expectedText, args) => {
+        waitForTextCalls.push([testID, expectedText, args])
+      },
       findByTestID: async (_testID, args) => {
         findArgs.push(args)
 
@@ -95,9 +97,8 @@ describe("Browser", () => {
     await browser.waitForTestIDText("statusText", "Ready")
     await browser.waitForTestIDTextExcludes("statusText", "stale")
 
+    expect(waitForTextCalls).toEqual([["statusText", "Ready", {timeout: 500}]])
     expect(findArgs).toEqual([
-      {timeout: 0},
-      {timeout: 0},
       {timeout: 0},
       {timeout: 0}
     ])

--- a/spec/system-test-finders.spec.js
+++ b/spec/system-test-finders.spec.js
@@ -224,6 +224,7 @@ describeIfWeb("SystemTest finders", () => {
 
         expect(existsCalls).toEqual(0)
       } finally {
+        clearRegisteredBrowserErrors(runningSystemTest)
         driverAdapter.exists = originalExists
       }
     })
@@ -243,6 +244,7 @@ describeIfWeb("SystemTest finders", () => {
           runningSystemTest.exists("[data-testid='blankText']", {useBaseSelector: false, timeout: 0})
         ).toBeRejectedWithError(/Browser error: exists fail after adapter/)
       } finally {
+        clearRegisteredBrowserErrors(runningSystemTest)
         driverAdapter.exists = originalExists
       }
     })
@@ -268,6 +270,7 @@ describeIfWeb("SystemTest finders", () => {
 
         expect(textCalls).toEqual(0)
       } finally {
+        clearRegisteredBrowserErrors(runningSystemTest)
         driverAdapter.text = originalText
       }
     })
@@ -287,6 +290,7 @@ describeIfWeb("SystemTest finders", () => {
           runningSystemTest.text("[data-testid='blankText']", {useBaseSelector: false, timeout: 0})
         ).toBeRejectedWithError(/Browser error: text fail after adapter/)
       } finally {
+        clearRegisteredBrowserErrors(runningSystemTest)
         driverAdapter.text = originalText
       }
     })
@@ -318,9 +322,13 @@ describeIfWeb("SystemTest finders", () => {
     await SystemTest.run(async (runningSystemTest) => {
       runningSystemTest.registerBrowserError({message: "finder fail fast"})
 
-      await expectAsync(
-        runningSystemTest.findByTestID("blankText", {useBaseSelector: false, timeout: 0})
-      ).toBeRejectedWithError(/Browser error: finder fail fast/)
+      try {
+        await expectAsync(
+          runningSystemTest.findByTestID("blankText", {useBaseSelector: false, timeout: 0})
+        ).toBeRejectedWithError(/Browser error: finder fail fast/)
+      } finally {
+        clearRegisteredBrowserErrors(runningSystemTest)
+      }
     })
   })
 
@@ -328,9 +336,13 @@ describeIfWeb("SystemTest finders", () => {
     await SystemTest.run(async (runningSystemTest) => {
       runningSystemTest.handleError({message: "finder rejection fail fast"})
 
-      await expectAsync(
-        runningSystemTest.findByTestID("blankText", {useBaseSelector: false, timeout: 0})
-      ).toBeRejectedWithError(/Browser error: finder rejection fail fast/)
+      try {
+        await expectAsync(
+          runningSystemTest.findByTestID("blankText", {useBaseSelector: false, timeout: 0})
+        ).toBeRejectedWithError(/Browser error: finder rejection fail fast/)
+      } finally {
+        clearRegisteredBrowserErrors(runningSystemTest)
+      }
     })
   })
 
@@ -374,3 +386,12 @@ describeIfWeb("SystemTest finders", () => {
     })
   })
 })
+
+/**
+ * Clears expected synthetic browser errors registered by fail-fast assertions.
+ * @param {SystemTest} systemTest Running system-test instance.
+ * @returns {void}
+ */
+function clearRegisteredBrowserErrors(systemTest) {
+  systemTest._browserErrors = []
+}

--- a/src/browser.js
+++ b/src/browser.js
@@ -449,13 +449,9 @@ export default class Browser {
   async waitForTestIDText(testID, expectedText, args = {}) {
     const {timeout: waitTimeout, ...findArgs} = args
 
-    await waitFor({timeout: this.getCommandTimeout(waitTimeout)}, async () => {
-      const element = await this.findByTestID(testID, {...findArgs, timeout: 0})
-      const actualText = await element.getText()
-
-      if (!actualText.includes(expectedText)) {
-        throw new Error(`Timed out waiting for text ${expectedText}. Last text was ${actualText}`)
-      }
+    await this.getDriverAdapter().waitForTestIDText(testID, expectedText, {
+      ...findArgs,
+      timeout: this.getCommandTimeout(waitTimeout)
     })
   }
 

--- a/src/drivers/appium-driver.js
+++ b/src/drivers/appium-driver.js
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises"
 import path from "node:path"
 import {Builder, By} from "selenium-webdriver"
+import {Command, Name} from "selenium-webdriver/lib/command.js"
 import {Origin} from "selenium-webdriver/lib/input.js"
 import {wait} from "awaitery"
 import timeout from "awaitery/build/timeout.js"
@@ -769,13 +770,21 @@ export default class AppiumDriver extends WebDriverDriver {
     const startY = Math.floor(windowRect.y + windowRect.height * 0.78)
     const endY = Math.floor(windowRect.y + windowRect.height * 0.28)
 
-    await this.getWebDriver()
-      .actions({async: true})
-      .move({origin: Origin.VIEWPORT, x: centerX, y: startY})
-      .press()
-      .move({duration: 250, origin: Origin.VIEWPORT, x: centerX, y: endY})
-      .release()
-      .perform()
+    await this.getWebDriver().execute(new Command(Name.ACTIONS).setParameter("actions", [
+      {
+        actions: [
+          {duration: 100, origin: Origin.VIEWPORT, type: "pointerMove", x: centerX, y: startY},
+          {button: 0, type: "pointerDown"},
+          {duration: 250, origin: Origin.VIEWPORT, type: "pointerMove", x: centerX, y: endY},
+          {button: 0, type: "pointerUp"}
+        ],
+        id: "native scroll finger",
+        parameters: {
+          pointerType: "touch"
+        },
+        type: "pointer"
+      }
+    ]))
   }
 
   /**

--- a/src/drivers/appium-driver.js
+++ b/src/drivers/appium-driver.js
@@ -115,6 +115,89 @@ function isUnsupportedMobileGestureError(error) {
 }
 
 /**
+ * Adds a UiAutomator text predicate to a resource-id selector.
+ * @param {string} resourceSelector UiAutomator resource-id selector.
+ * @param {string} filterSelector UiAutomator text or description selector.
+ * @returns {string} Combined selector.
+ */
+function combineAndroidSelectors(resourceSelector, filterSelector) {
+  const prefix = "new UiSelector()"
+
+  if (!filterSelector.startsWith(prefix)) {
+    throw new Error(`Expected Android selector to start with ${prefix}, got ${filterSelector}`)
+  }
+
+  return `${resourceSelector}${filterSelector.slice(prefix.length)}`
+}
+
+/**
+ * Adds a UiAutomator child predicate to a resource-id selector.
+ * @param {string} resourceSelector UiAutomator resource-id selector.
+ * @param {string} childSelector UiAutomator child selector.
+ * @returns {string} Combined selector.
+ */
+function childAndroidSelector(resourceSelector, childSelector) {
+  return `${resourceSelector}.childSelector(${childSelector})`
+}
+
+/**
+ * Escapes text for use as an XPath string literal.
+ * @param {string} value Unescaped XPath text.
+ * @returns {string} Quoted literal or concat expression safe for XPath.
+ */
+function xpathStringLiteral(value) {
+  if (!value.includes('"')) return `"${value}"`
+  if (!value.includes("'")) return `'${value}'`
+
+  return `concat(${value.split('"').map((part) => `"${part}"`).join(", '\"', ")})`
+}
+
+/**
+ * Builds an XPath selector for text under one native Android resource id.
+ * @param {string} testId Resource id suffix to scope under.
+ * @param {string} expectedText Text to locate inside that scope.
+ * @returns {string} XPath selector source.
+ */
+function androidScopedTextXpath(testId, expectedText) {
+  const resourceId = xpathStringLiteral(testId)
+  const text = xpathStringLiteral(expectedText)
+  const resourcePredicate = `(@resource-id = ${resourceId} or substring(@resource-id, string-length(@resource-id) - string-length(${resourceId}) + 1) = ${resourceId})`
+  const textPredicate = `(contains(@text, ${text}) or contains(@content-desc, ${text}))`
+
+  return `//*[${resourcePredicate} and ${textPredicate}] | //*[${resourcePredicate}]//*[${textPredicate}]`
+}
+
+/**
+ * Builds selectors that scope text matching to one native resource id.
+ * @param {string} testId Stable test id.
+ * @param {string} expectedText Text that must appear on that element.
+ * @returns {string[]} UiAutomator selectors.
+ */
+function nativeTestIDTextSelectors(testId, expectedText) {
+  const resourceSelector = androidResourceIdSelector(testId)
+
+  return [
+    combineAndroidSelectors(resourceSelector, androidTextContainsSelector(expectedText)),
+    combineAndroidSelectors(resourceSelector, androidDescriptionContainsSelector(expectedText)),
+    childAndroidSelector(resourceSelector, androidTextContainsSelector(expectedText)),
+    childAndroidSelector(resourceSelector, androidDescriptionContainsSelector(expectedText))
+  ]
+}
+
+/**
+ * Builds native Android scroll selectors for a scoped text assertion.
+ * @param {string} testId Stable test id.
+ * @param {string} expectedText Text that must appear on that element.
+ * @returns {string[]} UiAutomator selectors.
+ */
+function nativeTestIDTextScrollSelectors(testId, expectedText) {
+  return [
+    ...nativeTestIDTextSelectors(testId, expectedText),
+    androidResourceIdSelector(testId)
+  ]
+}
+
+/**
  * Ensures Chrome Appium capabilities use a caller-owned user-data directory.
  * This avoids repeated sessions leaking temp profiles under `/tmp` in CI.
  * @param {object} args
@@ -630,6 +713,46 @@ export default class AppiumDriver extends WebDriverDriver {
   }
 
   /**
+   * Waits until a test id owns expected visible text or an accessibility label.
+   * @param {string} testId Stable native resource id suffix.
+   * @param {string} expectedText Text that must appear under the test id.
+   * @param {FindArgs} [args] Optional lookup settings.
+   * @returns {Promise<void>}
+   */
+  async waitForTestIDText(testId, expectedText, args = {}) {
+    if (!this.isAndroidNativeAppContext()) {
+      await super.waitForTestIDText(testId, expectedText, args)
+      return
+    }
+
+    const selectors = nativeTestIDTextSelectors(testId, expectedText)
+    const scopedTextXpath = androidScopedTextXpath(testId, expectedText)
+    const directFind = async () => {
+      for (const selector of selectors) {
+        const elements = await this.getWebDriver().findElements(new By("-android uiautomator", selector))
+
+        if (elements.length > 1) {
+          throw new Error(`More than 1 elements (${elements.length}) were found by id ${testId} with text ${expectedText}`)
+        }
+        if (elements[0]) return elements[0]
+      }
+
+      const scopedTextElements = await this.getWebDriver().findElements(By.xpath(scopedTextXpath))
+      if (scopedTextElements[0]) return scopedTextElements[0]
+
+      throw new Error(`Element couldn't be found by id ${testId} with text ${expectedText}`)
+    }
+
+    await this.withNativeImplicitWait(0, async () => {
+      await this.findNativeControlWithScrolling({
+        description: `id ${testId} with text ${expectedText}`,
+        directFind,
+        scrollSelectors: nativeTestIDTextScrollSelectors(testId, expectedText)
+      }, {...args, scrollTo: args.scrollTo ?? true})
+    })
+  }
+
+  /**
    * Finds a native Android control by resource id, scrolling it into view first when requested.
    * @param {string} testId Stable native resource id suffix.
    * @param {FindArgs} [args] Optional lookup settings.
@@ -704,14 +827,15 @@ export default class AppiumDriver extends WebDriverDriver {
   }
 
   /**
-   * Searches native content from the top down so retained scroll offsets do not
-   * make controls above the current viewport unreachable.
+   * Searches native content around the current viewport so retained offsets and
+   * below-fold targets are both reachable without exhausting the timeout budget.
    * @param {() => Promise<import("selenium-webdriver").WebElement>} directFind Lookup to retry after each scroll.
    * @param {string[]} scrollContainerTestIDs Native test IDs that may identify scroll containers.
    * @returns {Promise<import("selenium-webdriver").WebElement>} Matching control.
    */
   async findNativeControlWithViewportScan(directFind, scrollContainerTestIDs) {
     const upScrollState = this.newNativeViewportScrollState()
+    const downScrollState = this.newNativeViewportScrollState()
 
     for (let index = 0; index < MAX_NATIVE_VIEWPORT_SCROLL_STEPS; index += 1) {
       await this.scrollNativeViewport(upScrollState, scrollContainerTestIDs, "up")
@@ -721,11 +845,7 @@ export default class AppiumDriver extends WebDriverDriver {
       } catch (error) {
         if (!isNativeControlLookupMiss(error)) throw error
       }
-    }
 
-    const downScrollState = this.newNativeViewportScrollState()
-
-    for (let index = 0; index < MAX_NATIVE_VIEWPORT_SCROLL_STEPS; index += 1) {
       await this.scrollNativeViewport(downScrollState, scrollContainerTestIDs, "down")
 
       try {

--- a/src/drivers/appium-driver.js
+++ b/src/drivers/appium-driver.js
@@ -7,6 +7,8 @@ import {wait} from "awaitery"
 import timeout from "awaitery/build/timeout.js"
 import WebDriverDriver from "./webdriver-driver.js"
 
+const MAX_NATIVE_VIEWPORT_SCROLL_STEPS = 8
+
 /**
  * Appium timeout values returned by Selenium.
  * @typedef {{implicit: number, pageLoad?: number, script?: number}} NativeTimeouts
@@ -22,6 +24,10 @@ import WebDriverDriver from "./webdriver-driver.js"
 /**
  * Tracks native scroll fallbacks that already reported no movement.
  * @typedef {{tryElementScroll: boolean, tryViewportScroll: boolean}} NativeViewportScrollState
+ */
+/**
+ * Native viewport scroll direction.
+ * @typedef {"down"|"up"} NativeViewportScrollDirection
  */
 /**
  * Native Android lookup work executed by the scrolling poller.
@@ -650,10 +656,6 @@ export default class AppiumDriver extends WebDriverDriver {
   async findNativeControlWithScrolling(lookup, args = {}) {
     const {scrollContainerTestIDs = [], scrollTo = true, timeout = 10000} = args
     const startTime = Date.now()
-    const viewportScrollState = {
-      tryElementScroll: true,
-      tryViewportScroll: true
-    }
     let attemptedUiSelectorScroll = false
     /** @type {unknown} */
     let lastError
@@ -685,10 +687,8 @@ export default class AppiumDriver extends WebDriverDriver {
           void error
         }
 
-        await this.scrollNativeViewportDown(viewportScrollState, scrollContainerTestIDs)
-
         try {
-          return await lookup.directFind()
+          return await this.findNativeControlWithViewportScan(lookup.directFind, scrollContainerTestIDs)
         } catch (error) {
           if (!isNativeControlLookupMiss(error)) throw error
           lastError = error
@@ -701,6 +701,51 @@ export default class AppiumDriver extends WebDriverDriver {
 
     const elapsedSeconds = (Date.now() - startTime) / 1000
     throw errorWithCause(`Element couldn't be found after ${elapsedSeconds.toFixed(2)}s by ${lookup.description}`, lastError)
+  }
+
+  /**
+   * Searches native content from the top down so retained scroll offsets do not
+   * make controls above the current viewport unreachable.
+   * @param {() => Promise<import("selenium-webdriver").WebElement>} directFind Lookup to retry after each scroll.
+   * @param {string[]} scrollContainerTestIDs Native test IDs that may identify scroll containers.
+   * @returns {Promise<import("selenium-webdriver").WebElement>} Matching control.
+   */
+  async findNativeControlWithViewportScan(directFind, scrollContainerTestIDs) {
+    const upScrollState = this.newNativeViewportScrollState()
+
+    for (let index = 0; index < MAX_NATIVE_VIEWPORT_SCROLL_STEPS; index += 1) {
+      await this.scrollNativeViewport(upScrollState, scrollContainerTestIDs, "up")
+
+      try {
+        return await directFind()
+      } catch (error) {
+        if (!isNativeControlLookupMiss(error)) throw error
+      }
+    }
+
+    const downScrollState = this.newNativeViewportScrollState()
+
+    for (let index = 0; index < MAX_NATIVE_VIEWPORT_SCROLL_STEPS; index += 1) {
+      await this.scrollNativeViewport(downScrollState, scrollContainerTestIDs, "down")
+
+      try {
+        return await directFind()
+      } catch (error) {
+        if (!isNativeControlLookupMiss(error)) throw error
+      }
+    }
+
+    throw new Error("Element couldn't be found after native viewport scan")
+  }
+
+  /**
+   * @returns {NativeViewportScrollState} Fresh scroll fallback state.
+   */
+  newNativeViewportScrollState() {
+    return {
+      tryElementScroll: true,
+      tryViewportScroll: true
+    }
   }
 
   /**
@@ -722,12 +767,13 @@ export default class AppiumDriver extends WebDriverDriver {
   }
 
   /**
-   * Scrolls the visible native viewport down when UiScrollable cannot identify the owning ScrollView.
+   * Scrolls the visible native viewport when UiScrollable cannot identify the owning ScrollView.
    * @param {NativeViewportScrollState} scrollState Per-lookup Appium scroll state.
    * @param {string[]} scrollContainerTestIDs Native test IDs that may identify scroll containers.
+   * @param {NativeViewportScrollDirection} direction Direction to scroll the content.
    * @returns {Promise<void>} Resolves after Appium performs the gesture.
    */
-  async scrollNativeViewportDown(scrollState, scrollContainerTestIDs) {
+  async scrollNativeViewport(scrollState, scrollContainerTestIDs, direction) {
     const windowRect = /** @type {NativeWindowRect} */ (await this.getWebDriver().manage().window().getRect())
     const horizontalInset = Math.max(1, Math.floor(windowRect.width * 0.1))
     const top = Math.max(1, Math.floor(windowRect.height * 0.2))
@@ -737,7 +783,7 @@ export default class AppiumDriver extends WebDriverDriver {
     if (scrollState.tryElementScroll && scrollContainerTestIDs.length > 0) {
       for (const scrollContainerTestID of scrollContainerTestIDs) {
         try {
-          const didScroll = await this.scrollNativeElementDown(scrollContainerTestID)
+          const didScroll = await this.scrollNativeElement(scrollContainerTestID, direction)
           if (didScroll) return
         } catch (error) {
           scrollState.tryElementScroll = false
@@ -751,7 +797,7 @@ export default class AppiumDriver extends WebDriverDriver {
     if (scrollState.tryViewportScroll) {
       try {
         const didScroll = await this.getWebDriver().executeScript("mobile: scrollGesture", {
-          direction: "down",
+          direction,
           height,
           left: horizontalInset,
           percent: 0.75,
@@ -767,8 +813,8 @@ export default class AppiumDriver extends WebDriverDriver {
     }
 
     const centerX = Math.floor(windowRect.x + windowRect.width / 2)
-    const startY = Math.floor(windowRect.y + windowRect.height * 0.78)
-    const endY = Math.floor(windowRect.y + windowRect.height * 0.28)
+    const startY = Math.floor(windowRect.y + windowRect.height * (direction === "down" ? 0.78 : 0.28))
+    const endY = Math.floor(windowRect.y + windowRect.height * (direction === "down" ? 0.28 : 0.78))
 
     await this.getWebDriver().execute(new Command(Name.ACTIONS).setParameter("actions", [
       {
@@ -790,16 +836,17 @@ export default class AppiumDriver extends WebDriverDriver {
   /**
    * Scrolls a specific native Android element by test id when Appium exposes it as a scroll container.
    * @param {string} testId Stable native resource id suffix.
+   * @param {NativeViewportScrollDirection} direction Direction to scroll the content.
    * @returns {Promise<boolean>} Whether Appium reported more content to scroll.
    */
-  async scrollNativeElementDown(testId) {
+  async scrollNativeElement(testId, direction) {
     const elements = await this.getWebDriver().findElements(new By("-android uiautomator", androidResourceIdSelector(testId)))
     const scrollElement = elements[0]
 
     if (!scrollElement) return false
 
     const didScroll = await this.getWebDriver().executeScript("mobile: scrollGesture", {
-      direction: "down",
+      direction,
       elementId: await scrollElement.getId(),
       percent: 0.75
     })

--- a/src/drivers/webdriver-driver.js
+++ b/src/drivers/webdriver-driver.js
@@ -1,6 +1,6 @@
 import {By, error as SeleniumError} from "selenium-webdriver"
 import logging from "selenium-webdriver/lib/logging.js"
-import {wait} from "awaitery"
+import {wait, waitFor} from "awaitery"
 import timeout from "awaitery/build/timeout.js"
 
 /**
@@ -586,6 +586,26 @@ export default class WebDriverDriver {
   async findByNativeText(expectedText, args = {}) {
     void args
     throw new Error(`findByNativeText is only supported for native Appium sessions: ${expectedText}`)
+  }
+
+  /**
+   * Waits until a test id contains expected visible text.
+   * @param {string} testID Element test id to inspect.
+   * @param {string} expectedText Fragment that must appear in the element text.
+   * @param {FindArgs} [args] Optional timeout and lookup settings.
+   * @returns {Promise<void>}
+   */
+  async waitForTestIDText(testID, expectedText, args = {}) {
+    const {timeout: waitTimeout = this.getTimeouts(), ...findArgs} = args
+
+    await waitFor({timeout: waitTimeout}, async () => {
+      const element = await this.findByTestID(testID, {...findArgs, timeout: 0})
+      const actualText = await element.getText()
+
+      if (!actualText.includes(expectedText)) {
+        throw new Error(`Timed out waiting for text ${expectedText}. Last text was ${actualText}`)
+      }
+    })
   }
 
   /**


### PR DESCRIPTION
## Summary
- send Appium native W3C scroll fallback actions as a touch pointer instead of Selenium's default mouse pointer
- assert the serialized fallback action payload uses pointerType=touch

## Verification
- npm test -- spec/appium-driver.spec.js
- npm run lint
- npm run typecheck
- git diff --check