### PR TITLE
feat: add human-like browser click mode

### DIFF
--- a/spec/cli-helpers.spec.js
+++ b/spec/cli-helpers.spec.js
@@ -82,6 +82,31 @@ describe("cli helpers", () => {
     expect(() => resolveBrowserCommand({find: ".card", timeout: "soon"})).toThrowError("Invalid timeout flag: soon")
   })
 
+  it("threads human click flags through convenience click commands", () => {
+    expect(resolveBrowserCommand({
+      click: "iframe[title='Security challenge widget']",
+      "click-offset-x": "32",
+      "click-offset-y": "28",
+      "human-step-delay": "75",
+      "human-steps": "5",
+      method: "human",
+      timeout: "20"
+    })).toEqual({
+      args: {
+        clickOffsetX: 32,
+        clickOffsetY: 28,
+        humanStepDelay: 75,
+        humanSteps: 5,
+        method: "human",
+        selector: "iframe[title='Security challenge widget']",
+        timeout: 20000,
+        useBaseSelector: undefined,
+        visible: undefined
+      },
+      command: "click"
+    })
+  })
+
   it("threads executeScript flags through the generic command path", () => {
     expect(resolveBrowserCommand({
       arg: ["one", "two"],

--- a/spec/webdriver-driver-interact.spec.js
+++ b/spec/webdriver-driver-interact.spec.js
@@ -424,6 +424,38 @@ describe("WebDriverDriver interact", () => {
     expect(actions.perform).toHaveBeenCalled()
   })
 
+  it("uses multiple pointer moves and pauses for human click interactions", async () => {
+    const element = {
+      getId: async () => "webdriver-element-id"
+    }
+    /** @type {{click: jasmine.Spy, move: jasmine.Spy, pause: jasmine.Spy, perform: jasmine.Spy}} */
+    const actions = /** @type {any} */ ({})
+    actions.click = jasmine.createSpy("click").and.returnValue(actions)
+    actions.move = jasmine.createSpy("move").and.returnValue(actions)
+    actions.pause = jasmine.createSpy("pause").and.returnValue(actions)
+    actions.perform = jasmine.createSpy("perform").and.resolveTo(undefined)
+    const driver = new WebDriverDriver({
+      browser: /** @type {any} */ ({
+        driver: undefined,
+        getSelector: (selector) => selector,
+        throwIfHttpServerError: () => {}
+      })
+    })
+
+    driver._findElement = async () => /** @type {any} */ (element)
+    driver.setWebDriver(/** @type {any} */ ({
+      actions: jasmine.createSpy("actions").and.returnValue(actions)
+    }))
+
+    await driver.click(element, {clickOffsetX: 32, clickOffsetY: 28, humanStepDelay: 75, humanSteps: 5, method: "human"})
+
+    expect(actions.move.calls.count()).toBeGreaterThan(1)
+    expect(actions.move.calls.mostRecent().args).toEqual([{origin: element, x: 32, y: 28}])
+    expect(actions.pause).toHaveBeenCalledWith(75)
+    expect(actions.click).toHaveBeenCalled()
+    expect(actions.perform).toHaveBeenCalled()
+  })
+
   it("dispatches element.click() via executeScript when method is 'js'", async () => {
     const element = {
       getId: async () => "webdriver-element-id"

--- a/src/browser-command-runner.js
+++ b/src/browser-command-runner.js
@@ -15,6 +15,22 @@ function parseCookieBoolean(fieldName, rawValue) {
   throw new Error(`addCookie ${fieldName} must be true or false, got ${JSON.stringify(rawValue)}`)
 }
 
+/**
+ * @param {string} fieldName
+ * @param {unknown} rawValue
+ * @returns {number | undefined}
+ */
+function parseOptionalNumber(fieldName, rawValue) {
+  if (rawValue === undefined) return undefined
+  const numberValue = Number(rawValue)
+
+  if (Number.isNaN(numberValue)) {
+    throw new Error(`${fieldName} must be a number, got ${JSON.stringify(rawValue)}`)
+  }
+
+  return numberValue
+}
+
 /** Runs browser commands across CLI and WebSocket transports. */
 export default class BrowserCommandRunner {
   /**
@@ -75,6 +91,18 @@ export default class BrowserCommandRunner {
         findArgs.scrollTo = commandArgs.scrollTo === "true"
       }
     }
+
+    if ("method" in commandArgs && commandArgs.method !== undefined) findArgs.method = commandArgs.method
+
+    const clickOffsetX = parseOptionalNumber("clickOffsetX", commandArgs.clickOffsetX)
+    const clickOffsetY = parseOptionalNumber("clickOffsetY", commandArgs.clickOffsetY)
+    const humanStepDelay = parseOptionalNumber("humanStepDelay", commandArgs.humanStepDelay)
+    const humanSteps = parseOptionalNumber("humanSteps", commandArgs.humanSteps)
+
+    if (clickOffsetX !== undefined) findArgs.clickOffsetX = clickOffsetX
+    if (clickOffsetY !== undefined) findArgs.clickOffsetY = clickOffsetY
+    if (humanStepDelay !== undefined) findArgs.humanStepDelay = humanStepDelay
+    if (humanSteps !== undefined) findArgs.humanSteps = humanSteps
 
     return findArgs
   }

--- a/src/cli-helpers.js
+++ b/src/cli-helpers.js
@@ -81,6 +81,40 @@ function resolveCliTimeout(timeoutFlag) {
 }
 
 /**
+ * @param {any} numberFlag
+ * @param {string} flagName
+ * @returns {number | undefined}
+ */
+function resolveCliNumber(numberFlag, flagName) {
+  if (numberFlag === undefined) return undefined
+  const numberValue = Number(numberFlag)
+
+  if (Number.isNaN(numberValue)) {
+    throw new Error(`Invalid ${flagName} flag: ${numberFlag}`)
+  }
+
+  return numberValue
+}
+
+/**
+ * @param {Record<string, any>} flags
+ * @param {Record<string, any>} args
+ * @returns {void}
+ */
+function applyPointerFlags(flags, args) {
+  const clickOffsetX = resolveCliNumber(flags["click-offset-x"], "click-offset-x")
+  const clickOffsetY = resolveCliNumber(flags["click-offset-y"], "click-offset-y")
+  const humanStepDelay = resolveCliNumber(flags["human-step-delay"], "human-step-delay")
+  const humanSteps = resolveCliNumber(flags["human-steps"], "human-steps")
+
+  if (flags.method !== undefined) args.method = flags.method
+  if (clickOffsetX !== undefined) args.clickOffsetX = clickOffsetX
+  if (clickOffsetY !== undefined) args.clickOffsetY = clickOffsetY
+  if (humanStepDelay !== undefined) args.humanStepDelay = humanStepDelay
+  if (humanSteps !== undefined) args.humanSteps = humanSteps
+}
+
+/**
  * @param {Record<string, any>} flags
  * @returns {{command: string, args: Record<string, any>}}
  */
@@ -155,6 +189,7 @@ export function resolveBrowserCommand(flags) {
       useBaseSelector: flags["use-base-selector"],
       visible: flags.visible
     }
+    applyPointerFlags(flags, args)
 
     if (flags["scroll-to"] !== undefined) {
       args.scrollTo = flags["scroll-to"]
@@ -217,6 +252,7 @@ export function resolveBrowserCommand(flags) {
     if (flags["test-id"]) args.testID = flags["test-id"]
     if (flags.method) args.methodName = flags.method
     if (flags.arg) args.args = Array.isArray(flags.arg) ? flags.arg : [flags.arg]
+    if (flags.command !== "interact") applyPointerFlags(flags, args)
     if (flags["with-fallback"] !== undefined) args.withFallback = flags["with-fallback"]
     if (timeout !== undefined) args.timeout = timeout
     if (flags["scroll-to"] !== undefined) args.scrollTo = flags["scroll-to"]

--- a/src/cli.js
+++ b/src/cli.js
@@ -14,6 +14,7 @@ function printHelp() {
   system-testing browser-command [--name my-browser] [--port 1991] --visit=https://example.com
   system-testing browser-command [--name my-browser] --find-by-test-id someID [--timeout 15]
   system-testing browser-command [--name my-browser] --take-screenshot
+  system-testing browser-command [--name my-browser] --click selector [--method human] [--click-offset-x 32] [--click-offset-y 28] [--human-steps 5] [--human-step-delay 75]
   system-testing browser-command [--name my-browser] --command=executeScript --script='return document.title' [--arg ...]
   system-testing browser-command [--name my-browser] --command=addCookie --cookie-name=auth --cookie-value=... [--cookie-domain=127.0.0.1] [--cookie-path=/]
 `)

--- a/src/drivers/webdriver-driver.js
+++ b/src/drivers/webdriver-driver.js
@@ -104,7 +104,11 @@ function shouldIgnoreBrowserLogEntry(entry, message) {
  * @typedef {object} FindArgs
  * @property {number} [timeout] Override timeout for lookup.
  * @property {boolean | null} [visible] Whether to require elements to be visible (`true`) or hidden (`false`). Use `null` to disable visibility filtering.
- * @property {"actions" | "js"} [method] Override the click path. `"actions"` uses the Selenium Actions API (real pointer move + click); `"js"` dispatches `element.click()` via `executeScript` inside the page's JS context (skips WebDriver's pointer synthesis entirely — useful when the default click is dropped by a framework responder that refuses synthetic WebDriver pointer events).
+ * @property {"actions" | "human" | "js"} [method] Override the click path. `"actions"` uses the Selenium Actions API (real pointer move + click); `"human"` uses multiple pointer moves and pauses before clicking; `"js"` dispatches `element.click()` via `executeScript` inside the page's JS context (skips WebDriver's pointer synthesis entirely — useful when the default click is dropped by a framework responder that refuses synthetic WebDriver pointer events).
+ * @property {number} [clickOffsetX] X offset for `actions`/`human` pointer clicks relative to the target element.
+ * @property {number} [clickOffsetY] Y offset for `actions`/`human` pointer clicks relative to the target element.
+ * @property {number} [humanStepDelay] Pause duration in ms between human pointer moves.
+ * @property {number} [humanSteps] Number of intermediate pointer moves before the final click target.
  * @property {boolean} [scrollTo] Whether to scroll found elements into view before returning them.
  * @property {string[]} [scrollContainerTestIDs] Native test IDs that should be tried as scroll containers before falling back to viewport gestures.
  * @property {boolean} [useBaseSelector] Whether to scope by the base selector.
@@ -654,7 +658,8 @@ export default class WebDriverDriver {
    * @returns {Promise<void>}
    */
   async click(elementOrIdentifier, args) {
-    const {method, scrollTo = false, ...findArgs} = args || {}
+    const {clickOffsetX, clickOffsetY, humanStepDelay, humanSteps, method, scrollTo = false, ...findArgs} = args || {}
+    const clickArgs = {clickOffsetX, clickOffsetY, humanStepDelay, humanSteps}
     let tries = 0
 
     while (true) {
@@ -668,7 +673,16 @@ export default class WebDriverDriver {
         }
 
         if (method === "actions") {
-          await this.getWebDriver().actions({async: true}).move({origin: element}).click().perform()
+          /** @type {{origin: import("selenium-webdriver").WebElement, x?: number, y?: number}} */
+          let moveArgs = {origin: element}
+
+          if (clickOffsetX !== undefined || clickOffsetY !== undefined) {
+            moveArgs = {origin: element, x: clickOffsetX ?? 0, y: clickOffsetY ?? 0}
+          }
+
+          await this.getWebDriver().actions({async: true}).move(moveArgs).click().perform()
+        } else if (method === "human") {
+          await this.humanClick(element, clickArgs)
         } else if (method === "js") {
           await this.getWebDriver().executeScript("arguments[0].click()", element)
         } else if (method === undefined) {
@@ -696,6 +710,36 @@ export default class WebDriverDriver {
         }
       }
     }
+  }
+
+  /**
+   * @param {import("selenium-webdriver").WebElement} element
+   * @param {{clickOffsetX?: number, clickOffsetY?: number, humanStepDelay?: number, humanSteps?: number}} [args]
+   * @returns {Promise<void>}
+   */
+  async humanClick(element, args = {}) {
+    const {clickOffsetX = 0, clickOffsetY = 0, humanStepDelay = 75, humanSteps = 4} = args
+    const steps = Math.max(1, Math.floor(humanSteps))
+    const actions = this.getWebDriver().actions({async: true})
+
+    for (let index = 0; index < steps; index++) {
+      const progress = (index + 1) / (steps + 1)
+      const wobble = index % 2 === 0 ? 6 : -4
+
+      actions
+        .move({
+          origin: element,
+          x: Math.round(clickOffsetX - ((1 - progress) * 80) + wobble),
+          y: Math.round(clickOffsetY - ((1 - progress) * 35) - wobble)
+        })
+        .pause(humanStepDelay)
+    }
+
+    await actions
+      .move({origin: element, x: clickOffsetX, y: clickOffsetY})
+      .pause(humanStepDelay)
+      .click()
+      .perform()
   }
 
   /**

--- a/src/system-test.js
+++ b/src/system-test.js
@@ -47,7 +47,11 @@ export function defaultClientWebSocketConnectTimeout() {
  * @typedef {object} FindArgs
  * @property {number} [timeout] Override timeout for lookup.
  * @property {boolean | null} [visible] Whether to require elements to be visible (`true`) or hidden (`false`). Use `null` to disable visibility filtering.
- * @property {"actions" | "js"} [method] Override the click path. `"actions"` uses the Selenium Actions API (real pointer move + click); `"js"` dispatches `element.click()` via `executeScript` inside the page's JS context (skips WebDriver's pointer synthesis entirely — useful when the default click is dropped by a framework responder that refuses synthetic WebDriver pointer events).
+ * @property {"actions" | "human" | "js"} [method] Override the click path. `"actions"` uses the Selenium Actions API (real pointer move + click); `"human"` uses multiple pointer moves and pauses before clicking; `"js"` dispatches `element.click()` via `executeScript` inside the page's JS context (skips WebDriver's pointer synthesis entirely — useful when the default click is dropped by a framework responder that refuses synthetic WebDriver pointer events).
+ * @property {number} [clickOffsetX] X offset for `actions`/`human` pointer clicks relative to the target element.
+ * @property {number} [clickOffsetY] Y offset for `actions`/`human` pointer clicks relative to the target element.
+ * @property {number} [humanStepDelay] Pause duration in ms between human pointer moves.
+ * @property {number} [humanSteps] Number of intermediate pointer moves before the final click target.
  * @property {boolean} [scrollTo] Whether to scroll found elements into view before returning them.
  * @property {string[]} [scrollContainerTestIDs] Native test IDs that should be tried as scroll containers before falling back to viewport gestures.
  * @property {boolean} [useBaseSelector] Whether to scope by the base selector.


### PR DESCRIPTION
## Summary
- Add a `method: human` browser click path using multiple WebDriver pointer moves and pauses before clicking
- Thread human-click options through the CLI and browser command runner
- Document the new CLI flags in `system-testing --help`

## Test Plan
- `npx jasmine spec/cli-helpers.spec.js spec/browser-command-runner.spec.js spec/webdriver-driver-interact.spec.js`
- `npm run typecheck`
- `npm run eslint`
- `npm run build`
- `npm test`