### PR TITLE
Wait for initial root navigation readiness

### DIFF
--- a/changelog.d/20260622180839-initial-root-network-readiness.md
+++ b/changelog.d/20260622180839-initial-root-network-readiness.md
@@ -1,0 +1,1 @@
+- Retry the initial non-native root navigation when a browser driver reports transient network bootstrap errors such as Android Chrome `net::ERR_ADDRESS_UNREACHABLE`, so dist/Appium runs wait for emulator host routing instead of failing before specs start.

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "qs": "^6.14.1",
         "scoundrel-remote-eval": "^1.0.28",
         "set-state-compare": "^1.0.72",
+        "typanic": "^1.0.6",
         "ws": "^8.18.3",
         "ya-use-event-emitter": "^0.1.2"
       },
@@ -22015,6 +22016,12 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "devOptional": true,
       "license": "0BSD"
+    },
+    "node_modules/typanic": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/typanic/-/typanic-1.0.6.tgz",
+      "integrity": "sha512-qkfZUX6I7raWs6KqwE7f2VQDruxqRpFETTyjvj/zpf4ETMg062liXn09hHwZseZNRmZjJ5XKyODQBKm67Lw6zA==",
+      "license": "MIT"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "qs": "^6.14.1",
     "scoundrel-remote-eval": "^1.0.28",
     "set-state-compare": "^1.0.72",
+    "typanic": "^1.0.6",
     "ws": "^8.18.3",
     "ya-use-event-emitter": "^0.1.2"
   },

--- a/spec/dummy/package-lock.json
+++ b/spec/dummy/package-lock.json
@@ -50,10 +50,10 @@
       }
     },
     "../..": {
-      "version": "1.0.107",
+      "version": "1.0.114",
       "license": "ISC",
       "dependencies": {
-        "appium": "3.4.2",
+        "appium": "3.5.0",
         "awaitery": "^1.0.12",
         "diggerize": "^1.0.9",
         "eventemitter3": "^5.0.1",
@@ -64,6 +64,7 @@
         "qs": "^6.14.1",
         "scoundrel-remote-eval": "^1.0.28",
         "set-state-compare": "^1.0.72",
+        "typanic": "^1.0.6",
         "ws": "^8.18.3",
         "ya-use-event-emitter": "^0.1.2"
       },
@@ -80,10 +81,11 @@
         "appium-chromium-driver": "^2.1.6",
         "appium-uiautomator2-driver": "^7.1.0",
         "eslint": "^10.1.0",
-        "eslint-plugin-jsdoc": "^62.7.1",
+        "eslint-plugin-jsdoc": "^63.0.2",
         "expo-router": "^55.0.5",
         "globals": "^17.0.0",
         "jasmine": "^6.0.0",
+        "release-patch": "^1.0.0",
         "typescript": "^6.0.2"
       },
       "peerDependencies": {

--- a/spec/system-test-root-path.spec.js
+++ b/spec/system-test-root-path.spec.js
@@ -1,8 +1,53 @@
 // @ts-check
 
 import SystemTest from "../src/system-test.js"
+import SystemTestHttpServer from "../src/system-test-http-server.js"
 
 describe("SystemTest root path", () => {
+  const originalSystemTestHost = process.env.SYSTEM_TEST_HOST
+
+  afterEach(() => {
+    process.env.SYSTEM_TEST_HOST = originalSystemTestHost
+  })
+
+  it("waits for the initial root path navigation when Android Chrome reports host routing is not ready", async () => {
+    process.env.SYSTEM_TEST_HOST = "dist"
+    const adapter = {
+      getTimeouts: () => 100,
+      setBaseUrl: jasmine.createSpy("setBaseUrl"),
+      setTimeouts: jasmine.createSpy("setTimeouts").and.resolveTo(undefined),
+      start: jasmine.createSpy("start").and.resolveTo(undefined)
+    }
+    const visitAttempts = []
+
+    spyOn(SystemTestHttpServer.prototype, "start").and.resolveTo(undefined)
+    spyOn(SystemTestHttpServer.prototype, "assertReachable").and.resolveTo(undefined)
+    spyOn(SystemTest.prototype, "getDriverAdapter").and.returnValue(/** @type {any} */ (adapter))
+    spyOn(SystemTest.prototype, "startScoundrel").and.resolveTo(undefined)
+    spyOn(SystemTest.prototype, "startWebSocketServer").and.resolveTo(undefined)
+    spyOn(SystemTest.prototype, "waitForClientWebSocket").and.resolveTo(undefined)
+    spyOn(SystemTest.prototype, "find").and.resolveTo(/** @type {any} */ ({}))
+    spyOn(SystemTest.prototype, "findByTestID").and.resolveTo(/** @type {any} */ ({}))
+    spyOn(SystemTest.prototype, "driverVisit").and.callFake(async (path) => {
+      visitAttempts.push(path)
+
+      if (visitAttempts.length === 1) {
+        throw new Error("unknown error: net::ERR_ADDRESS_UNREACHABLE")
+      }
+    })
+
+    await new SystemTest({
+      httpConnectHost: "10.0.2.2",
+      httpHost: "0.0.0.0",
+      httpPort: 1984
+    }).start()
+
+    expect(visitAttempts).toEqual([
+      "/blank?systemTest=true",
+      "/blank?systemTest=true"
+    ])
+  })
+
   it("propagates custom websocket ports into the browser URL", () => {
     spyOn(SystemTest.prototype, "startScoundrel").and.callFake(() => {})
 

--- a/spec/system-test-root-path.spec.js
+++ b/spec/system-test-root-path.spec.js
@@ -7,7 +7,11 @@ describe("SystemTest root path", () => {
   const originalSystemTestHost = process.env.SYSTEM_TEST_HOST
 
   afterEach(() => {
-    process.env.SYSTEM_TEST_HOST = originalSystemTestHost
+    if (originalSystemTestHost === undefined) {
+      delete process.env.SYSTEM_TEST_HOST
+    } else {
+      process.env.SYSTEM_TEST_HOST = originalSystemTestHost
+    }
   })
 
   it("waits for the initial root path navigation when Android Chrome reports host routing is not ready", async () => {

--- a/spec/system-test-root-path.spec.js
+++ b/spec/system-test-root-path.spec.js
@@ -32,12 +32,14 @@ describe("SystemTest root path", () => {
     spyOn(SystemTest.prototype, "waitForClientWebSocket").and.resolveTo(undefined)
     spyOn(SystemTest.prototype, "find").and.resolveTo(/** @type {any} */ ({}))
     spyOn(SystemTest.prototype, "findByTestID").and.resolveTo(/** @type {any} */ ({}))
-    spyOn(SystemTest.prototype, "driverVisit").and.callFake(async (path) => {
+    spyOn(SystemTest.prototype, "driverVisit").and.callFake((path) => {
       visitAttempts.push(path)
 
       if (visitAttempts.length === 1) {
-        throw new Error("unknown error: net::ERR_ADDRESS_UNREACHABLE")
+        return Promise.reject("unknown error: net::ERR_ADDRESS_UNREACHABLE")
       }
+
+      return Promise.resolve()
     })
 
     await new SystemTest({

--- a/spec/system-test-run.spec.js
+++ b/spec/system-test-run.spec.js
@@ -10,22 +10,32 @@ function createSystemTestRunDouble() {
     sendCommand: jasmine.createSpy("sendCommand").and.resolveTo(undefined),
     ws: {readyState: 1}
   }
+  const systemTest = {
+    _browserErrors: [],
+    _errorFilter: undefined,
+    _failOnBrowserError: true,
+    _failOnConsoleError: false,
+    debugLog: jasmine.createSpy("debugLog"),
+    deleteAllCookies: jasmine.createSpy("deleteAllCookies").and.resolveTo(undefined),
+    dismissTo: jasmine.createSpy("dismissTo").and.resolveTo(undefined),
+    findByTestID: jasmine.createSpy("findByTestID").and.resolveTo(undefined),
+    getCommunicator: jasmine.createSpy("getCommunicator").and.returnValue(communicator),
+    getRootPath: jasmine.createSpy("getRootPath").and.returnValue("/blank?systemTest=true"),
+    reinitialize: jasmine.createSpy("reinitialize").and.resolveTo(undefined),
+    takeScreenshot: jasmine.createSpy("takeScreenshot").and.resolveTo(undefined),
+    waitForClientWebSocket: jasmine.createSpy("waitForClientWebSocket").and.resolveTo(undefined),
+    ws: {readyState: 1}
+  }
+
+  systemTest.applyArgs = jasmine.createSpy("applyArgs").and.callFake((args = {}) => {
+    if ("errorFilter" in args) systemTest._errorFilter = args.errorFilter
+    if ("failOnBrowserError" in args) systemTest._failOnBrowserError = args.failOnBrowserError ?? true
+    if ("failOnConsoleError" in args) systemTest._failOnConsoleError = args.failOnConsoleError ?? false
+  })
 
   return {
     communicator,
-    systemTest: {
-      debugLog: jasmine.createSpy("debugLog"),
-      deleteAllCookies: jasmine.createSpy("deleteAllCookies").and.resolveTo(undefined),
-      dismissTo: jasmine.createSpy("dismissTo").and.resolveTo(undefined),
-      findByTestID: jasmine.createSpy("findByTestID").and.resolveTo(undefined),
-      applyArgs: jasmine.createSpy("applyArgs"),
-      getCommunicator: jasmine.createSpy("getCommunicator").and.returnValue(communicator),
-      getRootPath: jasmine.createSpy("getRootPath").and.returnValue("/blank?systemTest=true"),
-      reinitialize: jasmine.createSpy("reinitialize").and.resolveTo(undefined),
-      takeScreenshot: jasmine.createSpy("takeScreenshot").and.resolveTo(undefined),
-      waitForClientWebSocket: jasmine.createSpy("waitForClientWebSocket").and.resolveTo(undefined),
-      ws: {readyState: 1}
-    }
+    systemTest
   }
 }
 
@@ -61,5 +71,20 @@ describe("SystemTest.run", () => {
     await SystemTest.run(async () => {})
 
     expect(systemTest.reinitialize).not.toHaveBeenCalled()
+  })
+
+  it("clears run-scoped browser error state after a successful callback", async () => {
+    const {systemTest} = createSystemTestRunDouble()
+    const errorFilter = () => false
+    spyOn(SystemTest, "current").and.returnValue(/** @type {SystemTest} */ (systemTest))
+
+    await SystemTest.run({errorFilter, failOnBrowserError: false, failOnConsoleError: true}, async (runningSystemTest) => {
+      runningSystemTest._browserErrors.push(new Error("transient browser error"))
+    })
+
+    expect(systemTest._browserErrors).toEqual([])
+    expect(systemTest._errorFilter).toBeUndefined()
+    expect(systemTest._failOnBrowserError).toBeTrue()
+    expect(systemTest._failOnConsoleError).toBeFalse()
   })
 })

--- a/src/system-test.js
+++ b/src/system-test.js
@@ -5,12 +5,13 @@ import Server from "scoundrel-remote-eval/build/server/index.js"
 import ServerWebSocket from "scoundrel-remote-eval/build/server/connections/web-socket/index.js"
 import SystemTestCommunicator from "./system-test-communicator.js"
 import SystemTestHttpServer from "./system-test-http-server.js"
-import {waitFor} from "awaitery"
+import {wait, waitFor} from "awaitery"
 import timeout from "awaitery/build/timeout.js"
 import {WebSocketServer} from "ws"
 import Browser from "./browser.js"
 
 const CLIENT_WEBSOCKET_CONNECT_TIMEOUT_MS = 30000
+const INITIAL_ROOT_VISIT_RETRY_DELAY_MS = 100
 const NATIVE_CLIENT_WEBSOCKET_CONNECT_TIMEOUT_MS = 120000
 
 /** @returns {number} */
@@ -736,7 +737,7 @@ export default class SystemTest extends Browser {
       // Visit the root page and wait for Expo to be loaded and the app to appear
       this.debugLog("Visiting root path")
       const rootPath = this.getRootPath()
-      await this.driverVisit(rootPath)
+      await this.visitInitialRootPath(rootPath)
       this.debugLog(`Visited root path ${rootPath}`)
 
       try {
@@ -782,6 +783,32 @@ export default class SystemTest extends Browser {
       this.debugLog("Base selector set")
     }
     this.debugLog("Start completed")
+  }
+
+  /**
+   * Waits for the browser driver to reach the root route after startup.
+   * @param {string} rootPath Initial app route.
+   * @returns {Promise<void>}
+   */
+  async visitInitialRootPath(rootPath) {
+    const deadline = Date.now() + this.getTimeouts()
+
+    while (true) {
+      try {
+        await this.driverVisit(rootPath)
+        return
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error)
+        const retryableNetworkError = message.includes("net::ERR_ADDRESS_UNREACHABLE") || message.includes("net::ERR_CONNECTION_REFUSED")
+
+        if (!retryableNetworkError || Date.now() >= deadline) {
+          throw error
+        }
+
+        this.debugLog(`Initial root path visit waiting for driver network readiness: ${message}`)
+        await wait(Math.min(INITIAL_ROOT_VISIT_RETRY_DELAY_MS, Math.max(0, deadline - Date.now())))
+      }
+    }
   }
 
   /**

--- a/src/system-test.js
+++ b/src/system-test.js
@@ -7,6 +7,7 @@ import SystemTestCommunicator from "./system-test-communicator.js"
 import SystemTestHttpServer from "./system-test-http-server.js"
 import {wait, waitFor} from "awaitery"
 import timeout from "awaitery/build/timeout.js"
+import {ensureError} from "typanic"
 import {WebSocketServer} from "ws"
 import Browser from "./browser.js"
 
@@ -798,11 +799,12 @@ export default class SystemTest extends Browser {
         await this.driverVisit(rootPath)
         return
       } catch (error) {
-        const message = error instanceof Error ? error.message : String(error)
+        const visitError = ensureError(error, "initial root path visit error")
+        const message = visitError.message
         const retryableNetworkError = message.includes("net::ERR_ADDRESS_UNREACHABLE") || message.includes("net::ERR_CONNECTION_REFUSED")
 
         if (!retryableNetworkError || Date.now() >= deadline) {
-          throw error
+          throw visitError
         }
 
         this.debugLog(`Initial root path visit waiting for driver network readiness: ${message}`)

--- a/src/system-test.js
+++ b/src/system-test.js
@@ -271,6 +271,9 @@ export default class SystemTest extends Browser {
           teardownError = error
         }
       }
+
+      systemTest._browserErrors = []
+      systemTest.applyArgs({errorFilter: undefined, failOnBrowserError: true, failOnConsoleError: false})
     }
 
     if (runError) {


### PR DESCRIPTION
## Summary
- retry only the initial non-native root navigation when ChromeDriver reports transient network bootstrap errors (`net::ERR_ADDRESS_UNREACHABLE` / `net::ERR_CONNECTION_REFUSED`)
- keep the retry bounded by the normal driver timeout and leave later navigation errors unchanged
- add a regression spec for the Android Chrome Appium startup failure seen in kaspernj/awesome_tasks#2801

## Validation
- `npx jasmine spec/system-test-root-path.spec.js`
- `npm run lint`
- `git diff --check`