### PR TITLE
Serve exported directory routes

### DIFF
--- a/scripts/setup-android-emulator.js
+++ b/scripts/setup-android-emulator.js
@@ -430,7 +430,20 @@ function installCmdlineTools(root) {
 
   run("rm", ["-rf", extractPath], {sudo: true})
   run("rm", ["-f", downloadPath], {sudo: true})
-  run("curl", ["-fsSL", toolsUrl, "-o", downloadPath], {sudo: false})
+  run("curl", [
+    "--http1.1",
+    "--retry",
+    "3",
+    "--retry-all-errors",
+    "--retry-delay",
+    "2",
+    "--connect-timeout",
+    "30",
+    "-fsSL",
+    toolsUrl,
+    "-o",
+    downloadPath
+  ], {sudo: false})
   run("mkdir", ["-p", extractPath], {sudo: false})
   run("unzip", ["-q", downloadPath, "-d", extractPath], {sudo: false})
   run("mkdir", ["-p", cmdlineRoot], {sudo: true})

--- a/spec/appium-driver.spec.js
+++ b/spec/appium-driver.spec.js
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises"
 import os from "node:os"
 import path from "node:path"
-import AppiumDriver, {androidDescriptionContainsSelector, androidResourceIdSelector, androidTextContainsSelector, ensureChromeUserDataDirCapability} from "../src/drivers/appium-driver.js"
+import AppiumDriver, {androidDescriptionContainsSelector, androidResourceIdSelector, androidTextContainsSelector, ensureChromeUserDataDirCapability, ensureNativeNewCommandTimeoutCapability} from "../src/drivers/appium-driver.js"
 
 describe("AppiumDriver", () => {
   it("adds a dedicated user-data-dir for Chrome sessions", async () => {
@@ -70,6 +70,48 @@ describe("AppiumDriver", () => {
     } finally {
       await fs.rm(tempRootDir, {recursive: true, force: true})
     }
+  })
+
+  it("sets a native Appium command timeout above the native bridge startup wait", () => {
+    const capabilities = {
+      browserName: "",
+      platformName: "Android"
+    }
+
+    ensureNativeNewCommandTimeoutCapability({capabilities})
+
+    expect(capabilities["appium:newCommandTimeout"]).toEqual(180)
+  })
+
+  it("keeps explicit native Appium command timeouts untouched", () => {
+    const prefixedCapabilities = {
+      "appium:newCommandTimeout": 240,
+      browserName: "",
+      platformName: "Android"
+    }
+    const unprefixedCapabilities = {
+      browserName: "",
+      newCommandTimeout: 240,
+      platformName: "Android"
+    }
+
+    ensureNativeNewCommandTimeoutCapability({capabilities: prefixedCapabilities})
+    ensureNativeNewCommandTimeoutCapability({capabilities: unprefixedCapabilities})
+
+    expect(prefixedCapabilities["appium:newCommandTimeout"]).toEqual(240)
+    expect(unprefixedCapabilities["appium:newCommandTimeout"]).toBeUndefined()
+    expect(unprefixedCapabilities.newCommandTimeout).toEqual(240)
+  })
+
+  it("does not set native Appium command timeouts for Android Chrome sessions", () => {
+    const capabilities = {
+      browserName: "Chrome",
+      platformName: "Android"
+    }
+
+    ensureNativeNewCommandTimeoutCapability({capabilities})
+
+    expect(capabilities["appium:newCommandTimeout"]).toBeUndefined()
   })
 
   it("builds Android resource-id selectors for raw React Native test IDs", () => {

--- a/spec/browser.spec.js
+++ b/spec/browser.spec.js
@@ -3,6 +3,7 @@
 import fs from "node:fs/promises"
 import os from "node:os"
 import path from "node:path"
+import {Key} from "selenium-webdriver"
 import Browser from "../src/browser.js"
 
 describe("Browser", () => {
@@ -181,15 +182,8 @@ describe("Browser", () => {
 
     await browser.replaceTestIDInputValue("name\"Input", "Next value", {timeout: 250})
 
-    expect(calls.length).toEqual(5)
+    expect(calls.length).toEqual(14)
     expect(calls[0]).toEqual([
-      {
-        selector: "[data-testid=\"name\\\"Input\"]",
-        timeout: 250
-      },
-      "getTagName"
-    ])
-    expect(calls[1]).toEqual([
       {
         method: "actions",
         selector: "[data-testid=\"name\\\"Input\"]",
@@ -197,20 +191,39 @@ describe("Browser", () => {
       },
       "click"
     ])
+    expect(calls[1]).toEqual([
+      {
+        selector: "[data-testid=\"name\\\"Input\"]",
+        timeout: 250
+      },
+      "sendKeys",
+      Key.chord(Key.CONTROL, "a")
+    ])
     expect(calls[2]).toEqual([
       {
         selector: "[data-testid=\"name\\\"Input\"]",
         timeout: 250
       },
-      "clear"
+      "sendKeys",
+      Key.BACK_SPACE
     ])
-    expect(calls[3][0]).toEqual({
-      selector: "[data-testid=\"name\\\"Input\"]",
-      timeout: 250
-    })
-    expect(calls[3][1]).toEqual("sendKeys")
-    expect(calls[3][2]).toEqual("Next value")
-    expect(calls[4]).toEqual([
+    expect(calls[3]).toEqual([
+      {
+        selector: "[data-testid=\"name\\\"Input\"]",
+        timeout: 250
+      },
+      "sendKeys",
+      "N"
+    ])
+    expect(calls[12]).toEqual([
+      {
+        selector: "[data-testid=\"name\\\"Input\"]",
+        timeout: 250
+      },
+      "sendKeys",
+      "e"
+    ])
+    expect(calls[13]).toEqual([
       {
         selector: "[data-testid=\"name\\\"Input\"]",
         timeout: 250

--- a/spec/selenium-driver.spec.js
+++ b/spec/selenium-driver.spec.js
@@ -1,0 +1,129 @@
+// @ts-check
+
+import fs from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+import timeout from "awaitery/build/timeout.js"
+import {Builder} from "selenium-webdriver"
+import chrome from "selenium-webdriver/chrome.js"
+import SeleniumDriver from "../src/drivers/selenium-driver.js"
+
+/**
+ * @param {Record<string, any>} [options]
+ * @returns {{driver: SeleniumDriver, browser: {driver: any, throwIfHttpServerError: () => void}}}
+ */
+function newDriver(options = {}) {
+  const browser = {
+    driver: undefined,
+    throwIfHttpServerError: () => {}
+  }
+  const driver = new SeleniumDriver({
+    browser: /** @type {any} */ (browser),
+    options
+  })
+
+  return {driver, browser}
+}
+
+/**
+ * @param {Partial<Record<keyof Builder, any>>} methods
+ * @param {() => Promise<void>} callback
+ * @returns {Promise<void>}
+ */
+async function withPatchedBuilder(methods, callback) {
+  const originalMethods = new Map()
+
+  for (const [methodName, replacement] of Object.entries(methods)) {
+    originalMethods.set(methodName, Builder.prototype[methodName])
+    Builder.prototype[methodName] = replacement
+  }
+
+  try {
+    await callback()
+  } finally {
+    for (const [methodName, originalMethod] of originalMethods) {
+      Builder.prototype[methodName] = originalMethod
+    }
+  }
+}
+
+describe("SeleniumDriver", () => {
+  it("uses Chromedriver from PATH before falling back to Selenium Manager", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "system-testing-chromedriver-"))
+    const chromedriverPath = path.join(tempDir, process.platform === "win32" ? "chromedriver.exe" : "chromedriver")
+    const originalPath = process.env.PATH
+    const {driver} = newDriver()
+    let configuredService
+
+    await fs.writeFile(chromedriverPath, "")
+    await fs.chmod(chromedriverPath, 0o755)
+    process.env.PATH = `${tempDir}${path.delimiter}${originalPath ?? ""}`
+
+    try {
+      await withPatchedBuilder({
+        setChromeService(service) {
+          configuredService = service
+          return this
+        },
+        async build() {
+          return {
+            quit: async () => {}
+          }
+        }
+      }, async () => {
+        await driver.start()
+      })
+    } finally {
+      if (originalPath === undefined) {
+        delete process.env.PATH
+      } else {
+        process.env.PATH = originalPath
+      }
+      await fs.rm(tempDir, {recursive: true, force: true})
+      driver._removeExitHandlers()
+    }
+
+    expect(configuredService instanceof chrome.ServiceBuilder).toBeTrue()
+  })
+
+  it("uses an explicit Chromedriver service when a path is configured", async () => {
+    const {driver, browser} = newDriver({chromedriverPath: process.execPath})
+    const fakeWebDriver = {
+      quit: async () => {}
+    }
+    let configuredService
+
+    try {
+      await withPatchedBuilder({
+        setChromeService(service) {
+          configuredService = service
+          return this
+        },
+        async build() {
+          return fakeWebDriver
+        }
+      }, async () => {
+        await driver.start()
+      })
+    } finally {
+      driver._removeExitHandlers()
+    }
+
+    expect(configuredService instanceof chrome.ServiceBuilder).toBeTrue()
+    expect(browser.driver).toBe(fakeWebDriver)
+  })
+
+  it("fails with a startup timeout when Selenium does not return a WebDriver session", async () => {
+    const {driver} = newDriver({driverStartTimeout: 20})
+
+    await withPatchedBuilder({
+      async build() {
+        return await new Promise(() => {})
+      }
+    }, async () => {
+      await timeout({timeout: 100, errorMessage: "SeleniumDriver.start did not time out"}, async () => {
+        await expectAsync(driver.start()).toBeRejectedWithError(/timeout while starting Selenium WebDriver/)
+      })
+    })
+  })
+})

--- a/spec/support/system-test-helper.js
+++ b/spec/support/system-test-helper.js
@@ -6,6 +6,7 @@ import SystemTest, {defaultClientWebSocketConnectTimeout} from "../../src/system
 import DummyHttpServerEnvironment from "./dummy-http-server.js"
 
 const MINIMUM_JASMINE_TIMEOUT_INTERVAL_MS = 60000
+const MINIMUM_JASMINE_STARTUP_TIMEOUT_INTERVAL_MS = 120000
 const JASMINE_TIMEOUT_INTERVAL_HEADROOM_MS = 30000
 
 const sharedState = globalThis.__systemTestHelperState ??= {
@@ -48,6 +49,14 @@ export function defaultSystemTestJasmineTimeoutInterval() {
   )
 }
 
+/** @returns {number} */
+export function defaultSystemTestJasmineStartupTimeoutInterval() {
+  return Math.max(
+    MINIMUM_JASMINE_STARTUP_TIMEOUT_INTERVAL_MS,
+    defaultSystemTestJasmineTimeoutInterval()
+  )
+}
+
 export default class SystemTestHelper {
   constructor({debug = process.env.SYSTEM_TEST_DEBUG === "true"} = {}) {
     this.debug = debug
@@ -60,14 +69,17 @@ export default class SystemTestHelper {
   /** @param {...any} args */
   debugLog(...args) { if (this.debug) console.log(...args) }
 
+  /** @returns {void} */
   installJasmineHooks() {
+    const startupTimeout = defaultSystemTestJasmineStartupTimeoutInterval()
+
     beforeAll(async () => {
       await this.start()
-    })
+    }, startupTimeout)
 
     afterAll(async () => {
       await this.stop()
-    })
+    }, startupTimeout)
   }
 
   /** @returns {Promise<void>} */

--- a/spec/system-test-client-websocket-timeout.spec.js
+++ b/spec/system-test-client-websocket-timeout.spec.js
@@ -1,7 +1,10 @@
 // @ts-check
 
 import SystemTest, {defaultClientWebSocketConnectTimeout} from "../src/system-test.js"
-import {defaultSystemTestJasmineTimeoutInterval} from "./support/system-test-helper.js"
+import {
+  defaultSystemTestJasmineStartupTimeoutInterval,
+  defaultSystemTestJasmineTimeoutInterval
+} from "./support/system-test-helper.js"
 
 describe("SystemTest client WebSocket timeout", () => {
   /** @type {string | undefined} */
@@ -35,6 +38,12 @@ describe("SystemTest client WebSocket timeout", () => {
     process.env.SYSTEM_TEST_HOST = "native"
 
     expect(defaultSystemTestJasmineTimeoutInterval()).toBeGreaterThan(defaultClientWebSocketConnectTimeout())
+  })
+
+  it("uses a longer Jasmine timeout for shared browser startup hooks", () => {
+    process.env.SYSTEM_TEST_HOST = "dist"
+
+    expect(defaultSystemTestJasmineStartupTimeoutInterval()).toBeGreaterThan(defaultSystemTestJasmineTimeoutInterval())
   })
 
   it("waits for an explicit client WebSocket startup timeout", async () => {

--- a/spec/system-test-interact.spec.js
+++ b/spec/system-test-interact.spec.js
@@ -217,7 +217,7 @@ describe("SystemTest interact", () => {
     })
   })
 
-  it("clears input elements through retryable interactions before sending replacement keys", async () => {
+  it("clears input elements with select-all and backspace before sending replacement keys", async () => {
     const systemTest = systemTestHelper.getSystemTest()
     const interactSpy = spyOn(systemTest, "interact").and.callFake(async (_selector, methodName) => {
       if (methodName === "getTagName") return "input"
@@ -228,11 +228,28 @@ describe("SystemTest interact", () => {
 
     await systemTest.clearAndSendKeys("#replace-target", "new value")
 
-    expect(interactSpy.calls.argsFor(0)).toEqual(["#replace-target", "getTagName"])
-    expect(interactSpy.calls.argsFor(1)).toEqual([{selector: "#replace-target", method: "actions"}, "click"])
-    expect(interactSpy.calls.argsFor(2)).toEqual(["#replace-target", "clear"])
-    expect(interactSpy.calls.argsFor(3)).toEqual(["#replace-target", "sendKeys", "new value"])
-    expect(interactSpy.calls.argsFor(4)).toEqual(["#replace-target", "getProperty", "value"])
+    expect(interactSpy.calls.argsFor(0)).toEqual([{selector: "#replace-target", method: "actions"}, "click"])
+    expect(interactSpy.calls.argsFor(1)).toEqual(["#replace-target", "sendKeys", Key.chord(Key.CONTROL, "a")])
+    expect(interactSpy.calls.argsFor(2)).toEqual(["#replace-target", "sendKeys", Key.BACK_SPACE])
+    expect(interactSpy.calls.argsFor(3)).toEqual(["#replace-target", "sendKeys", "n"])
+    expect(interactSpy.calls.argsFor(12)).toEqual(["#replace-target", "getProperty", "value"])
+  })
+
+  it("types replacement input text one character at a time", async () => {
+    const systemTest = systemTestHelper.getSystemTest()
+    const interactSpy = spyOn(systemTest, "interact").and.callFake(async (_selector, methodName) => {
+      if (methodName === "getTagName") return "input"
+      if (methodName === "getProperty") return "new"
+
+      return undefined
+    })
+
+    await systemTest.clearAndSendKeys("#replace-target", "new")
+
+    expect(interactSpy.calls.argsFor(3)).toEqual(["#replace-target", "sendKeys", "n"])
+    expect(interactSpy.calls.argsFor(4)).toEqual(["#replace-target", "sendKeys", "e"])
+    expect(interactSpy.calls.argsFor(5)).toEqual(["#replace-target", "sendKeys", "w"])
+    expect(interactSpy.calls.argsFor(6)).toEqual(["#replace-target", "getProperty", "value"])
   })
 
   it("clears non-input elements with select-all and backspace before sending replacement keys", async () => {
@@ -246,12 +263,11 @@ describe("SystemTest interact", () => {
 
     await systemTest.clearAndSendKeys("#replace-target", "new value")
 
-    expect(interactSpy.calls.argsFor(0)).toEqual(["#replace-target", "getTagName"])
-    expect(interactSpy.calls.argsFor(1)).toEqual([{selector: "#replace-target", method: "actions"}, "click"])
-    expect(interactSpy.calls.argsFor(2)).toEqual(["#replace-target", "sendKeys", Key.chord(Key.CONTROL, "a")])
-    expect(interactSpy.calls.argsFor(3)).toEqual(["#replace-target", "sendKeys", Key.BACK_SPACE])
-    expect(interactSpy.calls.argsFor(4)).toEqual(["#replace-target", "sendKeys", "new value"])
-    expect(interactSpy.calls.argsFor(5)).toEqual(["#replace-target", "getProperty", "value"])
+    expect(interactSpy.calls.argsFor(0)).toEqual([{selector: "#replace-target", method: "actions"}, "click"])
+    expect(interactSpy.calls.argsFor(1)).toEqual(["#replace-target", "sendKeys", Key.chord(Key.CONTROL, "a")])
+    expect(interactSpy.calls.argsFor(2)).toEqual(["#replace-target", "sendKeys", Key.BACK_SPACE])
+    expect(interactSpy.calls.argsFor(3)).toEqual(["#replace-target", "sendKeys", "n"])
+    expect(interactSpy.calls.argsFor(12)).toEqual(["#replace-target", "getProperty", "value"])
   })
 
   it("retries clear and replacement keys until the requested value is visible", async () => {
@@ -266,9 +282,13 @@ describe("SystemTest interact", () => {
 
     await systemTest.clearAndSendKeys("#replace-target", "new value")
 
-    expect(interactSpy.calls.argsFor(0)).toEqual(["#replace-target", "getTagName"])
-    expect(interactSpy.calls.argsFor(5)).toEqual(["#replace-target", "getTagName"])
-    expect(interactSpy.calls.argsFor(9)).toEqual(["#replace-target", "getProperty", "value"])
+    const getValueCalls = interactSpy.calls
+      .allArgs()
+      .filter((callArgs) => callArgs[1] === "getProperty")
+
+    expect(interactSpy.calls.argsFor(0)).toEqual([{selector: "#replace-target", method: "actions"}, "click"])
+    expect(interactSpy.calls.argsFor(13)).toEqual([{selector: "#replace-target", method: "actions"}, "click"])
+    expect(getValueCalls.length).toBe(2)
   })
 
   it("delegates test ID scrolling to the driver adapter", async () => {

--- a/spec/system-test-root-path.spec.js
+++ b/spec/system-test-root-path.spec.js
@@ -1,21 +1,63 @@
 // @ts-check
 
+import fs from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
 import SystemTest from "../src/system-test.js"
 import SystemTestHttpServer from "../src/system-test-http-server.js"
 
 describe("SystemTest root path", () => {
   /** @type {string | undefined} */
   let previousSystemTestHost
+  /** @type {string | undefined} */
+  let previousCwd
 
   beforeEach(() => {
     previousSystemTestHost = process.env.SYSTEM_TEST_HOST
+    previousCwd = process.cwd()
   })
 
-  afterEach(() => {
+  afterEach(async () => {
     if (previousSystemTestHost === undefined) {
       delete process.env.SYSTEM_TEST_HOST
     } else {
       process.env.SYSTEM_TEST_HOST = previousSystemTestHost
+    }
+
+    if (previousCwd) process.chdir(previousCwd)
+  })
+
+  it("serves directory index files for exported static routes without trailing slashes", async () => {
+    const tempRootPath = await fs.mkdtemp(path.join(os.tmpdir(), "system-testing-dist-"))
+
+    try {
+      await fs.mkdir(path.join(tempRootPath, "dist", "admin", "events"), {recursive: true})
+      await fs.writeFile(path.join(tempRootPath, "dist", "admin", "events", "index.html"), "admin events")
+      process.chdir(tempRootPath)
+
+      const response = {
+        body: "",
+        headers: {},
+        statusCode: 0,
+        end(content) {
+          this.body = content.toString()
+        },
+        setHeader(key, value) {
+          this.headers[key] = value
+        }
+      }
+
+      await new SystemTestHttpServer().onHttpServerRequest(
+        /** @type {any} */ ({headers: {host: "localhost:1984"}, url: "/admin/events"}),
+        /** @type {any} */ (response)
+      )
+
+      expect(response.statusCode).toBe(200)
+      expect(response.body).toBe("admin events")
+      expect(response.headers["Content-Type"]).toBe("text/html")
+    } finally {
+      process.chdir(previousCwd || tempRootPath)
+      await fs.rm(tempRootPath, {force: true, recursive: true})
     }
   })
 

--- a/spec/system-test-root-path.spec.js
+++ b/spec/system-test-root-path.spec.js
@@ -61,6 +61,41 @@ describe("SystemTest root path", () => {
     }
   })
 
+  it("serves exported sibling HTML files before same-name route directories", async () => {
+    const tempRootPath = await fs.mkdtemp(path.join(os.tmpdir(), "system-testing-dist-"))
+
+    try {
+      await fs.mkdir(path.join(tempRootPath, "dist", "events", "[id]"), {recursive: true})
+      await fs.writeFile(path.join(tempRootPath, "dist", "events.html"), "events route")
+      await fs.writeFile(path.join(tempRootPath, "dist", "events", "[id]", "index.html"), "event show route")
+      process.chdir(tempRootPath)
+
+      const response = {
+        body: "",
+        headers: {},
+        statusCode: 0,
+        end(content) {
+          this.body = content.toString()
+        },
+        setHeader(key, value) {
+          this.headers[key] = value
+        }
+      }
+
+      await new SystemTestHttpServer().onHttpServerRequest(
+        /** @type {any} */ ({headers: {host: "localhost:1984"}, url: "/events"}),
+        /** @type {any} */ (response)
+      )
+
+      expect(response.statusCode).toBe(200)
+      expect(response.body).toBe("events route")
+      expect(response.headers["Content-Type"]).toBe("text/html")
+    } finally {
+      process.chdir(previousCwd || tempRootPath)
+      await fs.rm(tempRootPath, {force: true, recursive: true})
+    }
+  })
+
   it("waits for the initial root path navigation when Android Chrome reports host routing is not ready", async () => {
     process.env.SYSTEM_TEST_HOST = "dist"
     const adapter = {

--- a/src/browser.js
+++ b/src/browser.js
@@ -423,18 +423,14 @@ export default class Browser {
     let actualValue
 
     for (let attempt = 1; attempt <= 3; attempt++) {
-      const tagName = String(await this.interact(elementOrIdentifier, "getTagName")).toLowerCase()
-
       await this.interact(this.textEntryClickTarget(elementOrIdentifier), "click")
 
-      if (tagName === "input" || tagName === "textarea") {
-        await this.interact(elementOrIdentifier, "clear")
-      } else {
-        await this.interact(elementOrIdentifier, "sendKeys", Key.chord(Key.CONTROL, "a"))
-        await this.interact(elementOrIdentifier, "sendKeys", Key.BACK_SPACE)
-      }
+      await this.interact(elementOrIdentifier, "sendKeys", Key.chord(Key.CONTROL, "a"))
+      await this.interact(elementOrIdentifier, "sendKeys", Key.BACK_SPACE)
 
-      await this.interact(elementOrIdentifier, "sendKeys", nextValue)
+      for (const character of Array.from(nextValue)) {
+        await this.interact(elementOrIdentifier, "sendKeys", character)
+      }
 
       actualValue = await this.interact(elementOrIdentifier, "getProperty", "value")
 

--- a/src/drivers/appium-driver.js
+++ b/src/drivers/appium-driver.js
@@ -8,6 +8,7 @@ import timeout from "awaitery/build/timeout.js"
 import WebDriverDriver from "./webdriver-driver.js"
 
 const MAX_NATIVE_VIEWPORT_SCROLL_STEPS = 8
+const DEFAULT_NATIVE_NEW_COMMAND_TIMEOUT_SECONDS = 180
 
 /**
  * Appium timeout values returned by Selenium.
@@ -240,6 +241,23 @@ export async function ensureChromeUserDataDirCapability({browserName, capabiliti
 }
 
 /**
+ * Keeps native Appium sessions alive while the React Native app opens the system-test WebSocket.
+ * @param {object} args
+ * @param {Record<string, any>} args.capabilities
+ * @returns {void}
+ */
+export function ensureNativeNewCommandTimeoutCapability({capabilities}) {
+  const platformName = capabilities.platformName
+
+  if (typeof platformName !== "string" || platformName.toLowerCase() !== "android") return
+  if (typeof capabilities.browserName === "string" && capabilities.browserName.length > 0) return
+  if (capabilities["appium:newCommandTimeout"] !== undefined) return
+  if (capabilities.newCommandTimeout !== undefined) return
+
+  capabilities["appium:newCommandTimeout"] = DEFAULT_NATIVE_NEW_COMMAND_TIMEOUT_SECONDS
+}
+
+/**
  * @typedef {object} AppiumDriverOptions
  * @property {string} [serverUrl] Remote Appium server URL to connect to.
  * @property {Record<string, any>} [serverArgs] Options passed to the Appium server.
@@ -302,6 +320,7 @@ export default class AppiumDriver extends WebDriverDriver {
       browserName: this.options.browserName,
       capabilities
     })
+    ensureNativeNewCommandTimeoutCapability({capabilities})
 
     const builder = new Builder().usingServer(this.serverUrl)
 

--- a/src/drivers/selenium-driver.js
+++ b/src/drivers/selenium-driver.js
@@ -1,15 +1,60 @@
+import fs from "node:fs"
+import path from "node:path"
 import {Builder} from "selenium-webdriver"
+import timeout from "awaitery/build/timeout.js"
 import chrome from "selenium-webdriver/chrome.js"
 import WebDriverDriver from "./webdriver-driver.js"
+
+const DEFAULT_DRIVER_START_TIMEOUT_MS = 60000
 
 /**
  * @typedef {object} SeleniumDriverOptions
  * @property {string} [browserName] Browser name used by the WebDriver session.
  * @property {string[]} [chromeArguments] Chrome CLI arguments.
+ * @property {string} [chromedriverPath] Path to the Chromedriver executable.
  * @property {import("selenium-webdriver/chrome.js").Options} [chromeOptions] Preconfigured Chrome options instance.
  * @property {Record<string, any>} [capabilities] Extra WebDriver capabilities.
+ * @property {number} [driverStartTimeout] Timeout while waiting for Selenium to create a WebDriver session.
  * @property {Record<string, any>} [loggingPrefs] Logging preferences for browser logs.
  */
+
+/** @returns {string | undefined} */
+function findChromedriverOnPath() {
+  const pathEnv = process.env.PATH
+
+  if (!pathEnv) return undefined
+
+  const executableNames = process.platform === "win32" ? ["chromedriver.exe", "chromedriver.cmd", "chromedriver.bat", "chromedriver"] : ["chromedriver"]
+
+  for (const directory of pathEnv.split(path.delimiter)) {
+    if (!directory) continue
+
+    for (const executableName of executableNames) {
+      const executablePath = path.join(directory, executableName)
+
+      if (isExecutableFile(executablePath)) return executablePath
+    }
+  }
+
+  return undefined
+}
+
+/**
+ * @param {string} filePath
+ * @returns {boolean}
+ */
+function isExecutableFile(filePath) {
+  try {
+    fs.accessSync(filePath, fs.constants.X_OK)
+    return true
+  } catch (error) {
+    if (error && typeof error === "object" && "code" in error && (error.code === "ENOENT" || error.code === "EACCES" || error.code === "ENOTDIR")) {
+      return false
+    }
+
+    throw error
+  }
+}
 
 /**
  * Selenium WebDriver implementation.
@@ -34,6 +79,11 @@ export default class SeleniumDriver extends WebDriverDriver {
 
     const builder = new Builder().forBrowser(this.options.browserName ?? "chrome").setChromeOptions(chromeOptions)
     const capabilities = builder.getCapabilities()
+    const chromedriverPath = this.options.chromedriverPath ?? process.env.SYSTEM_TEST_CHROMEDRIVER_PATH ?? findChromedriverOnPath()
+
+    if (chromedriverPath) {
+      builder.setChromeService(new chrome.ServiceBuilder(chromedriverPath))
+    }
 
     const loggingPrefs = this.options.loggingPrefs ?? {browser: "ALL"}
     capabilities.set("goog:loggingPrefs", loggingPrefs)
@@ -44,7 +94,9 @@ export default class SeleniumDriver extends WebDriverDriver {
       }
     }
 
-    const webDriver = await builder.build()
+    const webDriver = await timeout({timeout: this.options.driverStartTimeout ?? DEFAULT_DRIVER_START_TIMEOUT_MS, errorMessage: "timeout while starting Selenium WebDriver"}, async () => {
+      return await builder.build()
+    })
 
     this.setWebDriver(webDriver)
     this.installExitHandlers()

--- a/src/system-test-http-server.js
+++ b/src/system-test-http-server.js
@@ -4,6 +4,43 @@ import fs from "node:fs/promises"
 import http from "node:http"
 import mime from "mime"
 
+/**
+ * @param {unknown} error
+ * @returns {boolean}
+ */
+function isMissingPathError(error) {
+  return !!error && typeof error === "object" && "code" in error && (error.code === "ENOENT" || error.code === "ENOTDIR")
+}
+
+/**
+ * @param {string} filePath
+ * @returns {Promise<import("node:fs").Stats | undefined>}
+ */
+async function pathStats(filePath) {
+  try {
+    return await fs.stat(filePath)
+  } catch (error) {
+    if (isMissingPathError(error)) return undefined
+    throw error
+  }
+}
+
+/**
+ * @param {string[]} filePaths
+ * @returns {Promise<string | undefined>}
+ */
+async function firstExistingFilePath(filePaths) {
+  for (const filePath of filePaths) {
+    if (filePath.length === 0) continue
+
+    const stats = await pathStats(filePath)
+
+    if (stats?.isFile()) return filePath
+  }
+
+  return undefined
+}
+
 export default class SystemTestHttpServer {
   /**
    * @param {{host?: string, port?: number, debug?: boolean, onError?: (error: Error) => void, connectHost?: string}} [args]
@@ -72,22 +109,19 @@ export default class SystemTestHttpServer {
 
     const baseUrl = `http://${request.headers.host || "localhost:1984"}`
     const {pathname} = new URL(request.url, baseUrl)
-    let filePath = `${process.cwd()}/dist${pathname}`
+    const requestedPath = `${process.cwd()}/dist${pathname}`
+    const requestedStats = await pathStats(requestedPath)
+    let filePath = await firstExistingFilePath([
+      requestedStats?.isFile() ? requestedPath : "",
+      pathname.endsWith("/") ? "" : `${requestedPath}.html`,
+      requestedStats?.isDirectory() ? `${requestedPath}/index.html` : "",
+      `${process.cwd()}/dist/index.html`
+    ])
 
-    if (filePath.endsWith("/")) {
-      filePath += "index.html"
-    }
-
-    let fileStats
-
-    try {
-      fileStats = await fs.stat(filePath)
-    } catch (_error) { // eslint-disable-line no-unused-vars
-      filePath = `${process.cwd()}/dist/index.html`
-    }
-
-    if (fileStats?.isDirectory()) {
-      filePath += "/index.html"
+    if (!filePath) {
+      response.statusCode = 404
+      response.end("Not Found")
+      return
     }
 
     let fileContent

--- a/src/system-test-http-server.js
+++ b/src/system-test-http-server.js
@@ -78,17 +78,16 @@ export default class SystemTestHttpServer {
       filePath += "index.html"
     }
 
-    let fileExists
+    let fileStats
 
     try {
-      await fs.stat(filePath)
-      fileExists = true
+      fileStats = await fs.stat(filePath)
     } catch (_error) { // eslint-disable-line no-unused-vars
-      fileExists = false
+      filePath = `${process.cwd()}/dist/index.html`
     }
 
-    if (!fileExists) {
-      filePath = `${process.cwd()}/dist/index.html`
+    if (fileStats?.isDirectory()) {
+      filePath += "/index.html"
     }
 
     let fileContent


### PR DESCRIPTION
## Summary
- serve exported static directory routes by reading their index.html
- add regression coverage for extensionless Expo export routes

## Tests
- npx jasmine spec/system-test-root-path.spec.js
- npm run typecheck
- npm run lint