### PR TITLE
Centralize and harden test ID selector escaping

### DIFF
--- a/spec/appium-driver.spec.js
+++ b/spec/appium-driver.spec.js
@@ -455,4 +455,34 @@ describe("AppiumDriver", () => {
 
     await expectAsync(driver.resolveAppiumMain()).toBeRejectedWithError("Appium main() is unavailable from the appium package")
   })
+
+  it("escapes quotes when finding by test ID with the CSS strategy", async () => {
+    const element = {}
+    const driver = new AppiumDriver({
+      browser: {},
+      options: {testIdStrategy: "css"}
+    })
+    const findSpy = jasmine.createSpy("find").and.resolveTo(element)
+
+    driver.find = /** @type {any} */ (findSpy)
+
+    await driver.findByTestID("name\"Input", {visible: false})
+
+    expect(findSpy).toHaveBeenCalledWith("[data-testid=\"name\\\"Input\"]", {visible: false})
+  })
+
+  it("escapes quotes for the CSS strategy with a custom test ID attribute", async () => {
+    const element = {}
+    const driver = new AppiumDriver({
+      browser: {},
+      options: {testIdStrategy: "css", testIdAttribute: "data-test"}
+    })
+    const findSpy = jasmine.createSpy("find").and.resolveTo(element)
+
+    driver.find = /** @type {any} */ (findSpy)
+
+    await driver.findByTestID("name\"Input")
+
+    expect(findSpy).toHaveBeenCalledWith("[data-test=\"name\\\"Input\"]", undefined)
+  })
 })

--- a/spec/test-id-selector.spec.js
+++ b/spec/test-id-selector.spec.js
@@ -1,0 +1,45 @@
+// @ts-check
+
+import {cssAttributeValue, testIdSelector} from "../src/test-id-selector.js"
+
+describe("test-id-selector", () => {
+  describe("cssAttributeValue", () => {
+    it("leaves simple values untouched", () => {
+      expect(cssAttributeValue("saveButton")).toEqual("saveButton")
+    })
+
+    it("escapes double quotes", () => {
+      expect(cssAttributeValue("name\"Input")).toEqual("name\\\"Input")
+    })
+
+    it("escapes backslashes", () => {
+      expect(cssAttributeValue("a\\b")).toEqual("a\\\\b")
+    })
+
+    it("escapes backslashes before quotes so the result stays balanced", () => {
+      expect(cssAttributeValue("a\\\"b")).toEqual("a\\\\\\\"b")
+    })
+
+    it("coerces non-string values to strings", () => {
+      expect(cssAttributeValue(42)).toEqual("42")
+    })
+  })
+
+  describe("testIdSelector", () => {
+    it("builds a double-quoted data-testid selector by default", () => {
+      expect(testIdSelector("saveButton")).toEqual("[data-testid=\"saveButton\"]")
+    })
+
+    it("escapes quotes and backslashes in the test ID", () => {
+      expect(testIdSelector("name\"In\\put")).toEqual("[data-testid=\"name\\\"In\\\\put\"]")
+    })
+
+    it("keeps bracket-like characters intact inside the quoted value", () => {
+      expect(testIdSelector("project.board/item[1]")).toEqual("[data-testid=\"project.board/item[1]\"]")
+    })
+
+    it("supports a custom attribute name", () => {
+      expect(testIdSelector("saveButton", "data-test")).toEqual("[data-test=\"saveButton\"]")
+    })
+  })
+})

--- a/spec/webdriver-driver-interact.spec.js
+++ b/spec/webdriver-driver-interact.spec.js
@@ -662,10 +662,49 @@ describe("WebDriverDriver interact", () => {
 
     await driver.scrollTestIdIntoView("project-environment-agent-submit", {timeout: 123})
 
-    expect(findScrollTargetSpy).toHaveBeenCalledWith("[data-testid='project-environment-agent-submit']", {timeout: 123})
+    expect(findScrollTargetSpy).toHaveBeenCalledWith("[data-testid=\"project-environment-agent-submit\"]", {timeout: 123})
     expect(webDriver.actions).toHaveBeenCalledWith({async: true})
     expect(moveSpy).toHaveBeenCalledWith({origin: element})
     expect(performSpy).toHaveBeenCalled()
+  })
+
+  it("escapes quotes in test IDs when finding by test ID", async () => {
+    const element = {}
+    const driver = new WebDriverDriver({
+      browser: /** @type {any} */ ({
+        driver: undefined,
+        getSelector: (selector) => selector,
+        throwIfHttpServerError: () => {}
+      })
+    })
+    const findSpy = jasmine.createSpy("find").and.resolveTo(element)
+
+    driver.find = /** @type {any} */ (findSpy)
+
+    await driver.findByTestID("name\"Input", {visible: false})
+
+    expect(findSpy).toHaveBeenCalledWith("[data-testid=\"name\\\"Input\"]", {visible: false})
+  })
+
+  it("escapes quotes in test IDs when scrolling a test ID into view", async () => {
+    const element = {getId: async () => "webdriver-element-id"}
+    const performSpy = jasmine.createSpy("perform").and.resolveTo(undefined)
+    const moveSpy = jasmine.createSpy("move").and.returnValue({perform: performSpy})
+    const driver = new WebDriverDriver({
+      browser: /** @type {any} */ ({
+        driver: undefined,
+        getSelector: (selector) => selector,
+        throwIfHttpServerError: () => {}
+      })
+    })
+    const findScrollTargetSpy = jasmine.createSpy("findScrollTarget").and.resolveTo(element)
+
+    driver.findScrollTarget = /** @type {any} */ (findScrollTargetSpy)
+    driver.setWebDriver(/** @type {any} */ ({actions: () => ({move: moveSpy})}))
+
+    await driver.scrollTestIdIntoView("name\"Input", {timeout: 0})
+
+    expect(findScrollTargetSpy).toHaveBeenCalledWith("[data-testid=\"name\\\"Input\"]", {timeout: 0})
   })
 
   it("falls back to rendered scroll targets without accepting hidden zero-size elements", async () => {

--- a/src/browser.js
+++ b/src/browser.js
@@ -8,6 +8,7 @@ import {wait, waitFor} from "awaitery"
 import timeout from "awaitery/build/timeout.js"
 import SeleniumDriver from "./drivers/selenium-driver.js"
 import AppiumDriver from "./drivers/appium-driver.js"
+import {testIdSelector} from "./test-id-selector.js"
 
 /**
  * @typedef {object} BrowserArgs
@@ -45,24 +46,6 @@ import AppiumDriver from "./drivers/appium-driver.js"
  * @typedef {object} BrowserTestIDInputArgs
  * @property {number} [timeout] Override timeout for the input lookup.
  */
-
-/**
- * Builds a data-testid CSS selector.
- * @param {string} testID Raw value from a `data-testid` attribute.
- * @returns {string} CSS attribute selector.
- */
-function testIdSelector(testID) {
-  return `[data-testid="${cssAttributeValue(testID)}"]`
-}
-
-/**
- * Escapes a value for use inside a double-quoted CSS attribute selector.
- * @param {string | number} value Raw attribute value.
- * @returns {string} Escaped selector value.
- */
-function cssAttributeValue(value) {
-  return String(value).replace(/\\/g, "\\\\").replace(/"/g, "\\\"")
-}
 
 /**
  * Extracts the RGB channels from CSS `rgb(...)`/`rgba(...)` values or an RGB fragment.

--- a/src/drivers/appium-driver.js
+++ b/src/drivers/appium-driver.js
@@ -6,6 +6,7 @@ import {Origin} from "selenium-webdriver/lib/input.js"
 import {wait} from "awaitery"
 import timeout from "awaitery/build/timeout.js"
 import WebDriverDriver from "./webdriver-driver.js"
+import {testIdSelector} from "../test-id-selector.js"
 
 const MAX_NATIVE_VIEWPORT_SCROLL_STEPS = 8
 const DEFAULT_NATIVE_NEW_COMMAND_TIMEOUT_SECONDS = 180
@@ -474,7 +475,7 @@ export default class AppiumDriver extends WebDriverDriver {
 
     if (testIdStrategy === "css") {
       const testIdAttribute = this.options.testIdAttribute ?? "data-testid"
-      return await this.find(`[${testIdAttribute}='${testID}']`, args)
+      return await this.find(testIdSelector(testID, testIdAttribute), args)
     }
     if (testIdStrategy === "id") {
       return await this.findById(testID, args)

--- a/src/drivers/webdriver-driver.js
+++ b/src/drivers/webdriver-driver.js
@@ -2,6 +2,7 @@ import {By, error as SeleniumError} from "selenium-webdriver"
 import logging from "selenium-webdriver/lib/logging.js"
 import {wait, waitFor} from "awaitery"
 import timeout from "awaitery/build/timeout.js"
+import {testIdSelector} from "../test-id-selector.js"
 
 /**
  * @param {string} message
@@ -604,7 +605,7 @@ export default class WebDriverDriver {
    * @returns {Promise<import("selenium-webdriver").WebElement>}
    */
   async findByTestID(testID, args) {
-    return await this.find(`[data-testid='${testID}']`, args)
+    return await this.find(testIdSelector(testID), args)
   }
 
   /**
@@ -921,7 +922,7 @@ export default class WebDriverDriver {
    * @returns {Promise<void>}
    */
   async scrollTestIdIntoView(testID, args) {
-    const element = await this.findScrollTarget(`[data-testid='${testID}']`, args)
+    const element = await this.findScrollTarget(testIdSelector(testID), args)
 
     await this.scrollElementIntoView(element)
   }

--- a/src/test-id-selector.js
+++ b/src/test-id-selector.js
@@ -1,0 +1,20 @@
+// @ts-check
+
+/**
+ * Escapes a value for use inside a double-quoted CSS attribute selector.
+ * @param {string | number} value Raw attribute value.
+ * @returns {string} Value safe to embed inside double quotes.
+ */
+export function cssAttributeValue(value) {
+  return String(value).replace(/\\/g, "\\\\").replace(/"/g, "\\\"")
+}
+
+/**
+ * Builds a `data-testid` (or custom attribute) CSS selector with a safely escaped test ID.
+ * @param {string} testID Raw test ID value.
+ * @param {string} [attribute] Attribute name, defaults to `data-testid`.
+ * @returns {string} CSS attribute selector like `[data-testid="value"]`.
+ */
+export function testIdSelector(testID, attribute = "data-testid") {
+  return `[${attribute}="${cssAttributeValue(testID)}"]`
+}


### PR DESCRIPTION
## What & why

AwesomeTasks #9975. `WebDriverDriver.findByTestID`/`scrollTestIdIntoView` and the Appium CSS test-ID strategy interpolated raw test IDs into **single-quoted** CSS attribute selectors with **no escaping**:

```js
this.find(`[data-testid='${testID}']`, args)        // webdriver-driver.js
this.find(`[${testIdAttribute}='${testID}']`, args) // appium-driver.js (css strategy)
```

A test ID containing a quote or backslash produced a broken or mis-targeted selector. `browser.js` already had a safe double-quoted escaper (`cssAttributeValue`/`testIdSelector`) but only used it for `replaceTestIDInputValue`.

## Changes

- **New `src/test-id-selector.js`** — shared selector utility: `cssAttributeValue(value)` (escapes `\` and `"` for a double-quoted attribute value) and `testIdSelector(testID, attribute = "data-testid")`.
- **`src/browser.js`** — removed the private duplicate helpers; imports the shared `testIdSelector` (used by `replaceTestIDInputValue`).
- **`src/drivers/webdriver-driver.js`** — `findByTestID` and `scrollTestIdIntoView` now build selectors via `testIdSelector`.
- **`src/drivers/appium-driver.js`** — the CSS test-ID strategy uses `testIdSelector(testID, testIdAttribute)`, preserving the configurable attribute.

All four test-ID CSS selector sites now share one safe builder. Selectors switch from single-quoted to double-quoted escaped form (e.g. `[data-testid="saveButton"]`) — equivalent for normal IDs, correct for unusual ones.

## Tests

- **New `spec/test-id-selector.spec.js`** — quotes, backslashes, backslash-before-quote, bracket characters, numeric coercion, custom attribute.
- **`spec/webdriver-driver-interact.spec.js`** — `findByTestID`/`scrollTestIdIntoView` build escaped selectors for a quote-containing test ID (updated the existing scroll assertion to the double-quoted form).
- **`spec/appium-driver.spec.js`** — CSS strategy escapes quotes, with default and custom `testIdAttribute`.

## Verification (local)

- `npm run lint` (eslint + typecheck) — clean
- `npm run build` — clean
- Focused + all non-browser unit specs — green (161/0)
- Full Default-checks repro (`node scripts/run-default-checks.js`, dist + Selenium) — **203 specs, 0 failures** (system tests use the new escaped selectors)

Appium Android emulator path defers to CI/TensorBuzz (no local `/dev/kvm`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
