### PR TITLE
Add explicit package exports map

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ For local or CI web runs against Chrome, `npm run test:appium:web` now resolves 
 `Browser` is the lower-level browser/session class behind `SystemTest`. Use it when you want driver-backed browsing, screenshots, logs, and HTML capture without the rest of the system-test bootstrapping.
 
 ```js
-import {Browser} from "system-testing/build/index.js"
+import {Browser} from "system-testing"
 
 const browser = new Browser()
 
@@ -326,7 +326,7 @@ Minimal example:
 
 ```jsx
 import {Stack} from "expo-router"
-import {useSystemTestExpo} from "system-testing/build/expo.js"
+import {useSystemTestExpo} from "system-testing/expo"
 
 export default function RootLayout() {
   const {enabled, systemTestBrowserHelper} = useSystemTestExpo({

--- a/package.json
+++ b/package.json
@@ -7,6 +7,18 @@
   },
   "main": "build/index.js",
   "types": "build/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./build/index.d.ts",
+      "default": "./build/index.js"
+    },
+    "./expo": {
+      "types": "./build/expo.d.ts",
+      "default": "./build/expo.js"
+    },
+    "./package.json": "./package.json",
+    "./build/*": "./build/*"
+  },
   "files": [
     "build/**"
   ],

--- a/spec/package-entrypoints.spec.js
+++ b/spec/package-entrypoints.spec.js
@@ -21,4 +21,49 @@ describe("package entrypoints", () => {
 
     expect(expoSource).toContain("use-system-test-expo")
   })
+
+  it("exposes the root entrypoint with types through the exports map", async () => {
+    const packageJson = JSON.parse(await fs.readFile(new URL("../package.json", import.meta.url), "utf8"))
+
+    expect(packageJson.exports["."]).toEqual({
+      types: "./build/index.d.ts",
+      default: "./build/index.js"
+    })
+  })
+
+  it("exposes the Expo Router hook through the ./expo subpath, not the root", async () => {
+    const packageJson = JSON.parse(await fs.readFile(new URL("../package.json", import.meta.url), "utf8"))
+
+    expect(packageJson.exports["./expo"]).toEqual({
+      types: "./build/expo.d.ts",
+      default: "./build/expo.js"
+    })
+    expect(packageJson.exports["."].default).not.toContain("expo")
+  })
+
+  it("keeps existing deep build imports and package.json resolvable", async () => {
+    const packageJson = JSON.parse(await fs.readFile(new URL("../package.json", import.meta.url), "utf8"))
+
+    expect(packageJson.exports["./build/*"]).toEqual("./build/*")
+    expect(packageJson.exports["./package.json"]).toEqual("./package.json")
+  })
+
+  it("ships every exports target inside the published build files", async () => {
+    const packageJson = JSON.parse(await fs.readFile(new URL("../package.json", import.meta.url), "utf8"))
+    const targets = []
+
+    for (const entry of Object.values(packageJson.exports)) {
+      if (typeof entry === "string") {
+        targets.push(entry)
+      } else {
+        for (const conditionTarget of Object.values(entry)) targets.push(conditionTarget)
+      }
+    }
+
+    for (const target of targets) {
+      if (!target.startsWith("./build/") || target.includes("*")) continue
+
+      await expectAsync(fs.access(new URL(`../${target.slice(2)}`, import.meta.url))).toBeResolved()
+    }
+  })
 })


### PR DESCRIPTION
## What & why

AwesomeTasks #9973. The package exposed its API only via `main`/`types` plus direct `build/...` paths, leaving the public surface implicit. This adds an explicit `exports` map with stable entrypoints while preserving the intentional Expo opt-in design — and without breaking existing deep imports.

## Exports map

```json
"exports": {
  ".":              { "types": "./build/index.d.ts", "default": "./build/index.js" },
  "./expo":         { "types": "./build/expo.d.ts",  "default": "./build/expo.js" },
  "./package.json": "./package.json",
  "./build/*":      "./build/*"
}
```

- **`.`** → the root API (`SystemTest`, `Browser`, …). `src/index.js` does not import the Expo hook, so the root never loads Expo Router.
- **`./expo`** → the Expo Router hook (`useSystemTestExpo`).
- **`./package.json`** and **`./build/*`** passthroughs keep tooling and existing deep `system-testing/build/...` imports working. This matters because the dummy app imports `system-testing/build/expo.js` and Metro/Expo SDK 54 enforces `exports` — so a strict map without the passthrough would break the dummy bundle. Net effect: clean entrypoints added, **no breaking change** (deep `build/*` was already publicly importable).

## Docs

README now shows the stable `import {Browser} from "system-testing"` and `import {useSystemTestExpo} from "system-testing/expo"` entrypoints. (Broader README import-path cleanup is the separate task #9972.)

## Tests

`spec/package-entrypoints.spec.js` now asserts: the `.` and `./expo` subpaths map to the built JS + `.d.ts`; the root default contains no `expo`; the `./build/*` and `./package.json` passthroughs exist; and every concrete `./build/...` target actually ships in the published files.

## Verification (local)

- `npm run build`, `npm run lint` (eslint + typecheck) — clean
- Entrypoint specs green
- Node self-reference: `import {SystemTest, Browser} from "system-testing"` loads in plain Node and pulls in **no** expo-router; `system-testing/expo` resolves through the map (loads Expo-only code, as intended)
- Full Default-checks repro (`node scripts/run-default-checks.js`, dist + Selenium) — **207 specs, 0 failures**; the dummy `export:web` (Metro) still bundles under the new map

Appium Android emulator path defers to CI/TensorBuzz (no local `/dev/kvm`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
