### PR TITLE
Prefer XPath for native test ID text lookups

### DIFF
--- a/changelog.d/20260702075000-native-testid-text-xpath-first.md
+++ b/changelog.d/20260702075000-native-testid-text-xpath-first.md
@@ -1,0 +1,1 @@
+- Prefer the scoped XPath lookup before UiAutomator text selectors for native Appium test-id text assertions, avoiding timeout exhaustion when React Native exposes the text on a descendant node.

--- a/changelog.d/20260702075000-native-testid-text-xpath-first.md
+++ b/changelog.d/20260702075000-native-testid-text-xpath-first.md
@@ -1,1 +1,2 @@
 - Prefer the scoped XPath lookup before UiAutomator text selectors for native Appium test-id text assertions, avoiding timeout exhaustion when React Native exposes the text on a descendant node.
+- Avoid duplicating configured system-test URL args when visiting routes that already carry those query params.

--- a/spec/appium-driver.spec.js
+++ b/spec/appium-driver.spec.js
@@ -260,6 +260,54 @@ describe("AppiumDriver", () => {
     expect(setTimeouts.calls.allArgs()).toEqual([[{implicit: 0}], [{implicit: 5000}]])
   })
 
+  it("scrolls native text waits by owner id instead of text selectors", async () => {
+    const element = {getId: async () => "native-test-id-text-element"}
+    const testId = "accountShowScreen/name/value"
+    const ownerSelector = androidResourceIdSelector(testId)
+    const childTextSelector = `${ownerSelector}.childSelector(${androidTextContainsSelector("Show Test Account")})`
+    const driver = new AppiumDriver({
+      browser: {
+        driver: undefined,
+        getSelector: (selector) => selector,
+        throwIfHttpServerError: () => {}
+      },
+      options: {
+        capabilities: {
+          platformName: "Android"
+        }
+      }
+    })
+    let childTextLookups = 0
+    const setTimeouts = jasmine.createSpy("setTimeouts").and.resolveTo()
+    const findElements = jasmine.createSpy("findElements").and.callFake(async (locator) => {
+      if (locator.value === childTextSelector) {
+        childTextLookups += 1
+
+        return childTextLookups > 1 ? [element] : []
+      }
+
+      if (locator.value?.includes("scrollIntoView(") && locator.value.includes("Show Test Account")) {
+        throw new Error(`Text-specific native scroll was attempted: ${locator.value}`)
+      }
+
+      return []
+    })
+
+    driver.setWebDriver(/** @type {import("selenium-webdriver").WebDriver} */ ({
+      findElements,
+      manage: () => ({
+        getTimeouts: async () => ({implicit: 5000}),
+        setTimeouts
+      })
+    }))
+
+    await expectAsync(driver.waitForTestIDText(testId, "Show Test Account", {timeout: 1000})).toBeResolved()
+    expect(findElements.calls.allArgs().some(([locator]) => (
+      locator.value === `new UiScrollable(new UiSelector().scrollable(true)).scrollIntoView(${ownerSelector})`
+    ))).toBeTrue()
+    expect(setTimeouts.calls.allArgs()).toEqual([[{implicit: 0}], [{implicit: 5000}]])
+  })
+
   it("scrolls native id lookups with caller-provided scroll containers", async () => {
     const element = {getId: async () => "native-id-element"}
     const targetSelector = androidResourceIdSelector("projectShowScreen/editButton")

--- a/spec/appium-driver.spec.js
+++ b/spec/appium-driver.spec.js
@@ -225,6 +225,41 @@ describe("AppiumDriver", () => {
     expect(setTimeouts.calls.allArgs()).toEqual([[{implicit: 0}], [{implicit: 5000}]])
   })
 
+  it("tries scoped xpath before native text selectors for text under a test id", async () => {
+    const element = {getId: async () => "native-test-id-text-element"}
+    const driver = new AppiumDriver({
+      browser: {
+        driver: undefined,
+        getSelector: (selector) => selector,
+        throwIfHttpServerError: () => {}
+      },
+      options: {
+        capabilities: {
+          platformName: "Android"
+        }
+      }
+    })
+    const setTimeouts = jasmine.createSpy("setTimeouts").and.resolveTo()
+    const findElements = jasmine.createSpy("findElements").and.callFake(async (locator) => {
+      if (locator.using === "xpath" && locator.value.includes("accountShowScreen/name/value")) return [element]
+
+      throw new Error(`Unexpected locator before scoped xpath: ${locator.using} ${locator.value}`)
+    })
+
+    driver.setWebDriver(/** @type {import("selenium-webdriver").WebDriver} */ ({
+      findElements,
+      manage: () => ({
+        getTimeouts: async () => ({implicit: 5000}),
+        setTimeouts
+      })
+    }))
+
+    await expectAsync(driver.waitForTestIDText("accountShowScreen/name/value", "Show Test Account", {timeout: 0})).toBeResolved()
+    expect(findElements.calls.count()).toEqual(1)
+    expect(findElements.calls.first().args[0].using).toEqual("xpath")
+    expect(setTimeouts.calls.allArgs()).toEqual([[{implicit: 0}], [{implicit: 5000}]])
+  })
+
   it("scrolls native id lookups with caller-provided scroll containers", async () => {
     const element = {getId: async () => "native-id-element"}
     const targetSelector = androidResourceIdSelector("projectShowScreen/editButton")

--- a/spec/appium-driver.spec.js
+++ b/spec/appium-driver.spec.js
@@ -225,8 +225,10 @@ describe("AppiumDriver", () => {
     expect(setTimeouts.calls.allArgs()).toEqual([[{implicit: 0}], [{implicit: 5000}]])
   })
 
-  it("tries scoped xpath before native text selectors for text under a test id", async () => {
+  it("prefers bounded native text selectors before scoped xpath for text under a test id", async () => {
     const element = {getId: async () => "native-test-id-text-element"}
+    const siblingElement = {getId: async () => "longer-native-test-id-text-element"}
+    const childTextSelector = `${androidResourceIdSelector("accountShowScreen/name/value")}.childSelector(${androidTextContainsSelector("Show Test Account")})`
     const driver = new AppiumDriver({
       browser: {
         driver: undefined,
@@ -241,9 +243,10 @@ describe("AppiumDriver", () => {
     })
     const setTimeouts = jasmine.createSpy("setTimeouts").and.resolveTo()
     const findElements = jasmine.createSpy("findElements").and.callFake(async (locator) => {
-      if (locator.using === "xpath" && locator.value.includes("accountShowScreen/name/value")) return [element]
+      if (locator.value === childTextSelector) return [element]
+      if (locator.using === "xpath" && locator.value.includes("accountShowScreen/name/value")) return [element, siblingElement]
 
-      throw new Error(`Unexpected locator before scoped xpath: ${locator.using} ${locator.value}`)
+      return []
     })
 
     driver.setWebDriver(/** @type {import("selenium-webdriver").WebDriver} */ ({
@@ -255,8 +258,8 @@ describe("AppiumDriver", () => {
     }))
 
     await expectAsync(driver.waitForTestIDText("accountShowScreen/name/value", "Show Test Account", {timeout: 0})).toBeResolved()
-    expect(findElements.calls.count()).toEqual(1)
-    expect(findElements.calls.first().args[0].using).toEqual("xpath")
+    expect(findElements.calls.allArgs().map(([locator]) => locator.value)).toContain(childTextSelector)
+    expect(findElements.calls.allArgs().some(([locator]) => locator.using === "xpath")).toBeFalse()
     expect(setTimeouts.calls.allArgs()).toEqual([[{implicit: 0}], [{implicit: 5000}]])
   })
 

--- a/spec/system-test-root-path.spec.js
+++ b/spec/system-test-root-path.spec.js
@@ -273,6 +273,27 @@ describe("SystemTest root path", () => {
     expect(url.searchParams.getAll("systemTestClientWsPort")).toEqual(["7001"])
     expect(url.searchParams.getAll("systemTestScoundrelPort")).toEqual(["7002"])
   })
+
+  it("does not duplicate explicit URL args that are already present in a visited path", () => {
+    spyOn(SystemTest.prototype, "startScoundrel").and.callFake(() => {})
+
+    const systemTest = new SystemTest({
+      urlArgs: {
+        backendHost: "127.0.0.1",
+        backendPort: "4282",
+        backendProtocol: "http",
+        systemTest: "true"
+      }
+    })
+
+    const path = systemTest.buildSystemTestPath("/projects?backendHost=127.0.0.1&backendPort=4282&backendProtocol=http&systemTest=true")
+    const url = new URL(path, "http://localhost")
+
+    expect(url.searchParams.getAll("backendHost")).toEqual(["127.0.0.1"])
+    expect(url.searchParams.getAll("backendPort")).toEqual(["4282"])
+    expect(url.searchParams.getAll("backendProtocol")).toEqual(["http"])
+    expect(url.searchParams.getAll("systemTest")).toEqual(["true"])
+  })
   it("ignores the known Chrome password-field DOM warning in live browser errors", () => {
     spyOn(SystemTest.prototype, "startScoundrel").and.callFake(() => {})
 

--- a/src/drivers/appium-driver.js
+++ b/src/drivers/appium-driver.js
@@ -3,7 +3,7 @@ import path from "node:path"
 import {Builder, By} from "selenium-webdriver"
 import {Command, Name} from "selenium-webdriver/lib/command.js"
 import {Origin} from "selenium-webdriver/lib/input.js"
-import {wait} from "awaitery"
+import {wait, waitFor} from "awaitery"
 import timeout from "awaitery/build/timeout.js"
 import WebDriverDriver from "./webdriver-driver.js"
 import {testIdSelector} from "../test-id-selector.js"
@@ -183,19 +183,6 @@ function nativeTestIDTextSelectors(testId, expectedText) {
     combineAndroidSelectors(resourceSelector, androidDescriptionContainsSelector(expectedText)),
     childAndroidSelector(resourceSelector, androidTextContainsSelector(expectedText)),
     childAndroidSelector(resourceSelector, androidDescriptionContainsSelector(expectedText))
-  ]
-}
-
-/**
- * Builds native Android scroll selectors for a scoped text assertion.
- * @param {string} testId Stable test id.
- * @param {string} expectedText Text that must appear on that element.
- * @returns {string[]} UiAutomator selectors.
- */
-function nativeTestIDTextScrollSelectors(testId, expectedText) {
-  return [
-    ...nativeTestIDTextSelectors(testId, expectedText),
-    androidResourceIdSelector(testId)
   ]
 }
 
@@ -798,6 +785,8 @@ export default class AppiumDriver extends WebDriverDriver {
       return
     }
 
+    const {scrollContainerTestIDs = [], scrollTo = true, timeout: waitTimeout = this.getTimeouts()} = args
+    const ownerSelector = androidResourceIdSelector(testId)
     const selectors = nativeTestIDTextSelectors(testId, expectedText)
     const scopedTextXpath = androidScopedTextXpath(testId, expectedText)
     const directFind = async () => {
@@ -820,11 +809,27 @@ export default class AppiumDriver extends WebDriverDriver {
     }
 
     await this.withNativeImplicitWait(0, async () => {
-      await this.findNativeControlWithScrolling({
-        description: `id ${testId} with text ${expectedText}`,
-        directFind,
-        scrollSelectors: nativeTestIDTextScrollSelectors(testId, expectedText)
-      }, {...args, scrollTo: args.scrollTo ?? true})
+      try {
+        await directFind()
+        return
+      } catch (error) {
+        if (!isNativeControlLookupMiss(error)) throw error
+      }
+
+      if (scrollTo) {
+        try {
+          await this.scrollNativeUiSelectorIntoView(ownerSelector, scrollContainerTestIDs)
+        } catch (error) {
+          void error
+        }
+      }
+
+      if (waitTimeout === 0) {
+        await directFind()
+        return
+      }
+
+      await waitFor({timeout: waitTimeout}, directFind)
     })
   }
 

--- a/src/drivers/appium-driver.js
+++ b/src/drivers/appium-driver.js
@@ -801,6 +801,12 @@ export default class AppiumDriver extends WebDriverDriver {
     const selectors = nativeTestIDTextSelectors(testId, expectedText)
     const scopedTextXpath = androidScopedTextXpath(testId, expectedText)
     const directFind = async () => {
+      const scopedTextElements = await this.getWebDriver().findElements(By.xpath(scopedTextXpath))
+      if (scopedTextElements.length > 1) {
+        throw new Error(`More than 1 elements (${scopedTextElements.length}) were found by id ${testId} with text ${expectedText}`)
+      }
+      if (scopedTextElements[0]) return scopedTextElements[0]
+
       for (const selector of selectors) {
         const elements = await this.getWebDriver().findElements(new By("-android uiautomator", selector))
 
@@ -809,9 +815,6 @@ export default class AppiumDriver extends WebDriverDriver {
         }
         if (elements[0]) return elements[0]
       }
-
-      const scopedTextElements = await this.getWebDriver().findElements(By.xpath(scopedTextXpath))
-      if (scopedTextElements[0]) return scopedTextElements[0]
 
       throw new Error(`Element couldn't be found by id ${testId} with text ${expectedText}`)
     }

--- a/src/drivers/appium-driver.js
+++ b/src/drivers/appium-driver.js
@@ -790,12 +790,6 @@ export default class AppiumDriver extends WebDriverDriver {
     const selectors = nativeTestIDTextSelectors(testId, expectedText)
     const scopedTextXpath = androidScopedTextXpath(testId, expectedText)
     const directFind = async () => {
-      const scopedTextElements = await this.getWebDriver().findElements(By.xpath(scopedTextXpath))
-      if (scopedTextElements.length > 1) {
-        throw new Error(`More than 1 elements (${scopedTextElements.length}) were found by id ${testId} with text ${expectedText}`)
-      }
-      if (scopedTextElements[0]) return scopedTextElements[0]
-
       for (const selector of selectors) {
         const elements = await this.getWebDriver().findElements(new By("-android uiautomator", selector))
 
@@ -804,6 +798,12 @@ export default class AppiumDriver extends WebDriverDriver {
         }
         if (elements[0]) return elements[0]
       }
+
+      const scopedTextElements = await this.getWebDriver().findElements(By.xpath(scopedTextXpath))
+      if (scopedTextElements.length > 1) {
+        throw new Error(`More than 1 elements (${scopedTextElements.length}) were found by id ${testId} with text ${expectedText}`)
+      }
+      if (scopedTextElements[0]) return scopedTextElements[0]
 
       throw new Error(`Element couldn't be found by id ${testId} with text ${expectedText}`)
     }

--- a/src/system-test.js
+++ b/src/system-test.js
@@ -939,6 +939,10 @@ export default class SystemTest extends Browser {
   buildSystemTestPath(path) {
     const isAbsoluteUrl = /^[a-z]+:\/\//i.test(path)
     const url = new URL(path, "http://localhost")
+    const setParam = (/** @type {string} */ key, /** @type {any} */ value) => {
+      if (value === undefined || value === null) return
+      url.searchParams.set(key, String(value))
+    }
     const appendParam = (/** @type {string} */ key, /** @type {any} */ value) => {
       if (value === undefined || value === null) return
       url.searchParams.append(key, String(value))
@@ -947,11 +951,11 @@ export default class SystemTest extends Browser {
     if (this._urlArgs) {
       if (this._urlArgs instanceof URLSearchParams) {
         for (const [key, value] of this._urlArgs) {
-          appendParam(key, value)
+          setParam(key, value)
         }
       } else {
         for (const [key, value] of Object.entries(this._urlArgs)) {
-          appendParam(key, value)
+          setParam(key, value)
         }
       }
     }


### PR DESCRIPTION
## Summary
- try the scoped XPath lookup before slower UiAutomator text selectors for native Appium test-id text assertions
- keep duplicate-element protection on the XPath path
- add focused coverage for lookup order

## Validation
- npm test -- spec/appium-driver.spec.js
- npm run lint