### PR TITLE
Keep native text waits scroll-aware

### DIFF
--- a/spec/appium-driver.spec.js
+++ b/spec/appium-driver.spec.js
@@ -263,6 +263,45 @@ describe("AppiumDriver", () => {
     expect(setTimeouts.calls.allArgs()).toEqual([[{implicit: 0}], [{implicit: 5000}]])
   })
 
+  it("falls back to owner element text when native scoped text selectors miss", async () => {
+    const testId = "accountShowScreen/name/value"
+    const ownerSelector = androidResourceIdSelector(testId)
+    const element = {
+      getId: async () => "native-owner-text-element",
+      getText: async () => "Show Test Account"
+    }
+    const driver = new AppiumDriver({
+      browser: {
+        driver: undefined,
+        getSelector: (selector) => selector,
+        throwIfHttpServerError: () => {}
+      },
+      options: {
+        capabilities: {
+          platformName: "Android"
+        }
+      }
+    })
+    const setTimeouts = jasmine.createSpy("setTimeouts").and.resolveTo()
+    const findElements = jasmine.createSpy("findElements").and.callFake(async (locator) => {
+      if (locator.value === ownerSelector) return [element]
+
+      return []
+    })
+
+    driver.setWebDriver(/** @type {import("selenium-webdriver").WebDriver} */ ({
+      findElements,
+      manage: () => ({
+        getTimeouts: async () => ({implicit: 5000}),
+        setTimeouts
+      })
+    }))
+
+    await expectAsync(driver.waitForTestIDText(testId, "Show Test Account", {timeout: 0})).toBeResolved()
+    expect(findElements.calls.allArgs().map(([locator]) => locator.value)).toContain(ownerSelector)
+    expect(setTimeouts.calls.allArgs()).toEqual([[{implicit: 0}], [{implicit: 5000}]])
+  })
+
   it("scrolls native text waits by owner id instead of text selectors", async () => {
     const element = {getId: async () => "native-test-id-text-element"}
     const testId = "accountShowScreen/name/value"

--- a/spec/appium-driver.spec.js
+++ b/spec/appium-driver.spec.js
@@ -302,6 +302,61 @@ describe("AppiumDriver", () => {
     expect(setTimeouts.calls.allArgs()).toEqual([[{implicit: 0}], [{implicit: 5000}]])
   })
 
+  it("polls visible native text owners without viewport scanning while text is pending", async () => {
+    const testId = "accountShowScreen/name/value"
+    const ownerSelector = androidResourceIdSelector(testId)
+    const childTextSelector = `${ownerSelector}.childSelector(${androidTextContainsSelector("Show Test Account")})`
+    const element = {getId: async () => "native-test-id-text-element"}
+    const ownerElement = {
+      getId: async () => "native-owner-text-element",
+      getText: async () => "Loading account"
+    }
+    const driver = new AppiumDriver({
+      browser: {
+        driver: undefined,
+        getSelector: (selector) => selector,
+        throwIfHttpServerError: () => {}
+      },
+      options: {
+        capabilities: {
+          platformName: "Android"
+        }
+      }
+    })
+    let childTextLookups = 0
+    const setTimeouts = jasmine.createSpy("setTimeouts").and.resolveTo()
+    const executeScript = jasmine.createSpy("executeScript").and.rejectWith(new Error("Native viewport scan was attempted"))
+    const findElements = jasmine.createSpy("findElements").and.callFake(async (locator) => {
+      if (locator.value === childTextSelector) {
+        childTextLookups += 1
+
+        return childTextLookups > 2 ? [element] : []
+      }
+
+      if (locator.value === ownerSelector) return [ownerElement]
+      if (locator.value?.includes("scrollIntoView(")) throw new Error(`Native UiScrollable was attempted: ${locator.value}`)
+
+      return []
+    })
+
+    driver.setWebDriver(/** @type {import("selenium-webdriver").WebDriver} */ ({
+      executeScript,
+      findElements,
+      manage: () => ({
+        getTimeouts: async () => ({implicit: 5000}),
+        setTimeouts,
+        window: () => ({
+          getRect: async () => ({x: 0, y: 0, width: 400, height: 800})
+        })
+      })
+    }))
+
+    await expectAsync(driver.waitForTestIDText(testId, "Show Test Account", {timeout: 200})).toBeResolved()
+    expect(executeScript).not.toHaveBeenCalled()
+    expect(childTextLookups).toBeGreaterThan(2)
+    expect(setTimeouts.calls.allArgs()).toEqual([[{implicit: 0}], [{implicit: 5000}]])
+  })
+
   it("scrolls native text waits by owner id instead of text selectors", async () => {
     const element = {getId: async () => "native-test-id-text-element"}
     const testId = "accountShowScreen/name/value"

--- a/spec/appium-driver.spec.js
+++ b/spec/appium-driver.spec.js
@@ -281,12 +281,13 @@ describe("AppiumDriver", () => {
       }
     })
     let childTextLookups = 0
+    let downScrolls = 0
     const setTimeouts = jasmine.createSpy("setTimeouts").and.resolveTo()
     const findElements = jasmine.createSpy("findElements").and.callFake(async (locator) => {
       if (locator.value === childTextSelector) {
         childTextLookups += 1
 
-        return childTextLookups > 1 ? [element] : []
+        return downScrolls > 0 ? [element] : []
       }
 
       if (locator.value?.includes("scrollIntoView(") && locator.value.includes("Show Test Account")) {
@@ -297,10 +298,19 @@ describe("AppiumDriver", () => {
     })
 
     driver.setWebDriver(/** @type {import("selenium-webdriver").WebDriver} */ ({
+      executeScript: jasmine.createSpy("executeScript").and.callFake(async (script, args) => {
+        if (script !== "mobile: scrollGesture") return undefined
+        if (args.direction === "down") downScrolls += 1
+
+        return true
+      }),
       findElements,
       manage: () => ({
         getTimeouts: async () => ({implicit: 5000}),
-        setTimeouts
+        setTimeouts,
+        window: () => ({
+          getRect: async () => ({x: 0, y: 0, width: 400, height: 800})
+        })
       })
     }))
 
@@ -308,6 +318,8 @@ describe("AppiumDriver", () => {
     expect(findElements.calls.allArgs().some(([locator]) => (
       locator.value === `new UiScrollable(new UiSelector().scrollable(true)).scrollIntoView(${ownerSelector})`
     ))).toBeTrue()
+    expect(downScrolls).toBeGreaterThan(0)
+    expect(childTextLookups).toBeGreaterThan(1)
     expect(setTimeouts.calls.allArgs()).toEqual([[{implicit: 0}], [{implicit: 5000}]])
   })
 

--- a/spec/system-test-root-path.spec.js
+++ b/spec/system-test-root-path.spec.js
@@ -138,6 +138,48 @@ describe("SystemTest root path", () => {
     ])
   })
 
+  it("does not bound initial root path network retries by the normal driver command timeout", async () => {
+    process.env.SYSTEM_TEST_HOST = "dist"
+    const adapter = {
+      getTimeouts: () => 1,
+      setBaseUrl: jasmine.createSpy("setBaseUrl"),
+      setTimeouts: jasmine.createSpy("setTimeouts").and.resolveTo(undefined),
+      start: jasmine.createSpy("start").and.resolveTo(undefined)
+    }
+    const visitAttempts = []
+
+    spyOn(SystemTestHttpServer.prototype, "start").and.resolveTo(undefined)
+    spyOn(SystemTestHttpServer.prototype, "assertReachable").and.resolveTo(undefined)
+    spyOn(SystemTest.prototype, "getDriverAdapter").and.returnValue(/** @type {any} */ (adapter))
+    spyOn(SystemTest.prototype, "startScoundrel").and.resolveTo(undefined)
+    spyOn(SystemTest.prototype, "startWebSocketServer").and.resolveTo(undefined)
+    spyOn(SystemTest.prototype, "waitForClientWebSocket").and.resolveTo(undefined)
+    spyOn(SystemTest.prototype, "find").and.resolveTo(/** @type {any} */ ({}))
+    spyOn(SystemTest.prototype, "findByTestID").and.resolveTo(/** @type {any} */ ({}))
+    spyOn(SystemTest.prototype, "driverVisit").and.callFake((path) => {
+      visitAttempts.push(path)
+
+      if (visitAttempts.length < 3) {
+        return Promise.reject("unknown error: net::ERR_ADDRESS_UNREACHABLE")
+      }
+
+      return Promise.resolve()
+    })
+
+    await new SystemTest({
+      httpConnectHost: "10.0.2.2",
+      httpHost: "0.0.0.0",
+      httpPort: 1984,
+      initialRootVisitTimeout: 350
+    }).start()
+
+    expect(visitAttempts).toEqual([
+      "/blank?systemTest=true",
+      "/blank?systemTest=true",
+      "/blank?systemTest=true"
+    ])
+  })
+
   it("starts the client WebSocket before launching native Appium sessions even when serving dist", async () => {
     process.env.SYSTEM_TEST_HOST = "dist"
     const startupCalls = []

--- a/src/drivers/appium-driver.js
+++ b/src/drivers/appium-driver.js
@@ -805,6 +805,16 @@ export default class AppiumDriver extends WebDriverDriver {
       }
       if (scopedTextElements[0]) return scopedTextElements[0]
 
+      const ownerElements = await this.getWebDriver().findElements(new By("-android uiautomator", ownerSelector))
+      if (ownerElements.length > 1) {
+        throw new Error(`More than 1 elements (${ownerElements.length}) were found by id ${testId}`)
+      }
+      if (ownerElements[0]) {
+        const actualText = await ownerElements[0].getText()
+
+        if (actualText.includes(expectedText)) return ownerElements[0]
+      }
+
       throw new Error(`Element couldn't be found by id ${testId} with text ${expectedText}`)
     }
 

--- a/src/drivers/appium-driver.js
+++ b/src/drivers/appium-driver.js
@@ -3,7 +3,7 @@ import path from "node:path"
 import {Builder, By} from "selenium-webdriver"
 import {Command, Name} from "selenium-webdriver/lib/command.js"
 import {Origin} from "selenium-webdriver/lib/input.js"
-import {wait, waitFor} from "awaitery"
+import {wait} from "awaitery"
 import timeout from "awaitery/build/timeout.js"
 import WebDriverDriver from "./webdriver-driver.js"
 import {testIdSelector} from "../test-id-selector.js"
@@ -809,27 +809,16 @@ export default class AppiumDriver extends WebDriverDriver {
     }
 
     await this.withNativeImplicitWait(0, async () => {
-      try {
-        await directFind()
-        return
-      } catch (error) {
-        if (!isNativeControlLookupMiss(error)) throw error
-      }
-
-      if (scrollTo) {
-        try {
-          await this.scrollNativeUiSelectorIntoView(ownerSelector, scrollContainerTestIDs)
-        } catch (error) {
-          void error
-        }
-      }
-
-      if (waitTimeout === 0) {
-        await directFind()
-        return
-      }
-
-      await waitFor({timeout: waitTimeout}, directFind)
+      await this.findNativeControlWithScrolling({
+        description: `id ${testId} with text ${expectedText}`,
+        directFind,
+        scrollSelectors: [ownerSelector]
+      }, {
+        ...args,
+        scrollContainerTestIDs,
+        scrollTo,
+        timeout: waitTimeout
+      })
     })
   }
 

--- a/src/drivers/appium-driver.js
+++ b/src/drivers/appium-driver.js
@@ -3,7 +3,7 @@ import path from "node:path"
 import {Builder, By} from "selenium-webdriver"
 import {Command, Name} from "selenium-webdriver/lib/command.js"
 import {Origin} from "selenium-webdriver/lib/input.js"
-import {wait} from "awaitery"
+import {wait, waitFor} from "awaitery"
 import timeout from "awaitery/build/timeout.js"
 import WebDriverDriver from "./webdriver-driver.js"
 import {testIdSelector} from "../test-id-selector.js"
@@ -789,6 +789,15 @@ export default class AppiumDriver extends WebDriverDriver {
     const ownerSelector = androidResourceIdSelector(testId)
     const selectors = nativeTestIDTextSelectors(testId, expectedText)
     const scopedTextXpath = androidScopedTextXpath(testId, expectedText)
+    const findOwner = async () => {
+      const ownerElements = await this.getWebDriver().findElements(new By("-android uiautomator", ownerSelector))
+      if (ownerElements.length > 1) {
+        throw new Error(`More than 1 elements (${ownerElements.length}) were found by id ${testId}`)
+      }
+      if (ownerElements[0]) return ownerElements[0]
+
+      throw new Error(`Element couldn't be found by id ${testId}`)
+    }
     const directFind = async () => {
       for (const selector of selectors) {
         const elements = await this.getWebDriver().findElements(new By("-android uiautomator", selector))
@@ -805,30 +814,49 @@ export default class AppiumDriver extends WebDriverDriver {
       }
       if (scopedTextElements[0]) return scopedTextElements[0]
 
-      const ownerElements = await this.getWebDriver().findElements(new By("-android uiautomator", ownerSelector))
-      if (ownerElements.length > 1) {
-        throw new Error(`More than 1 elements (${ownerElements.length}) were found by id ${testId}`)
-      }
-      if (ownerElements[0]) {
-        const actualText = await ownerElements[0].getText()
+      const ownerElement = await findOwner()
+      const actualText = await ownerElement.getText()
+      if (actualText.includes(expectedText)) return ownerElement
 
-        if (actualText.includes(expectedText)) return ownerElements[0]
-      }
-
-      throw new Error(`Element couldn't be found by id ${testId} with text ${expectedText}`)
+      throw new Error(`Timed out waiting for text ${expectedText}. Last text was ${actualText}`)
     }
 
     await this.withNativeImplicitWait(0, async () => {
-      await this.findNativeControlWithScrolling({
-        description: `id ${testId} with text ${expectedText}`,
-        directFind,
-        scrollSelectors: [ownerSelector]
-      }, {
-        ...args,
-        scrollContainerTestIDs,
-        scrollTo,
-        timeout: waitTimeout
-      })
+      try {
+        await directFind()
+        return
+      } catch (error) {
+        if (!isNativeControlLookupMiss(error)) {
+          if (waitTimeout === 0) throw error
+
+          await waitFor({timeout: waitTimeout}, directFind)
+          return
+        }
+      }
+
+      if (scrollTo) {
+        try {
+          await this.findNativeControlWithScrolling({
+            description: `id ${testId}`,
+            directFind: findOwner,
+            scrollSelectors: [ownerSelector]
+          }, {
+            ...args,
+            scrollContainerTestIDs,
+            scrollTo,
+            timeout: 0
+          })
+        } catch (error) {
+          if (!isNativeControlLookupMiss(error)) throw error
+        }
+      }
+
+      if (waitTimeout === 0) {
+        await directFind()
+        return
+      }
+
+      await waitFor({timeout: waitTimeout}, directFind)
     })
   }
 

--- a/src/system-test.js
+++ b/src/system-test.js
@@ -14,6 +14,7 @@ import {isAppiumNativeAppDriverConfig} from "./drivers/appium-driver.js"
 
 const CLIENT_WEBSOCKET_CONNECT_TIMEOUT_MS = 30000
 const CLIENT_WEBSOCKET_SERVER_LISTEN_TIMEOUT_MS = 15000
+const DEFAULT_INITIAL_ROOT_VISIT_TIMEOUT_MS = 60000
 const INITIAL_ROOT_VISIT_RETRY_DELAY_MS = 100
 const NATIVE_CLIENT_WEBSOCKET_CONNECT_TIMEOUT_MS = 120000
 
@@ -48,6 +49,7 @@ export function defaultClientWebSocketConnectTimeout({driver} = {}) {
  * @property {boolean} [failOnConsoleError] Treat browser console.error calls as registered browser errors.
  * @property {number} [clientWsPort] Port for the browser-command WebSocket server.
  * @property {number} [clientWsConnectTimeout] Timeout for the browser-command WebSocket client connection.
+ * @property {number} [initialRootVisitTimeout] Timeout for retrying the first browser route visit.
  * @property {number} [scoundrelPort] Port for the Scoundrel WebSocket server.
  * @property {Record<string, any>} [urlArgs] Query params appended to the root path.
  * @property {SystemTestDriverConfig} [driver] Driver configuration.
@@ -105,6 +107,7 @@ export default class SystemTest extends Browser {
   _started = false
   _clientWsPort = 1985
   _clientWsConnectTimeout = CLIENT_WEBSOCKET_CONNECT_TIMEOUT_MS
+  _initialRootVisitTimeout = DEFAULT_INITIAL_ROOT_VISIT_TIMEOUT_MS
   _httpHost = "localhost"
   _httpPort = 1984
   _failOnBrowserError = true
@@ -399,7 +402,7 @@ export default class SystemTest extends Browser {
    * Creates a new SystemTest instance
    * @param {SystemTestArgs} [args]
    */
-  constructor({clientWsPort = 1985, clientWsConnectTimeout, host = "localhost", port = 8081, httpHost = "localhost", httpPort = 1984, httpConnectHost, debug = false, errorFilter, failOnBrowserError = true, failOnConsoleError = false, scoundrelPort = 8090, urlArgs, driver, ...restArgs} = {host: "localhost", port: 8081, httpHost: "localhost", httpPort: 1984, debug: false}) {
+  constructor({clientWsPort = 1985, clientWsConnectTimeout, initialRootVisitTimeout = DEFAULT_INITIAL_ROOT_VISIT_TIMEOUT_MS, host = "localhost", port = 8081, httpHost = "localhost", httpPort = 1984, httpConnectHost, debug = false, errorFilter, failOnBrowserError = true, failOnConsoleError = false, scoundrelPort = 8090, urlArgs, driver, ...restArgs} = {host: "localhost", port: 8081, httpHost: "localhost", httpPort: 1984, debug: false}) {
     super({debug, driver})
 
     const restArgsKeys = Object.keys(restArgs)
@@ -412,6 +415,7 @@ export default class SystemTest extends Browser {
     this._port = port
     this._clientWsPort = clientWsPort
     this._clientWsConnectTimeout = clientWsConnectTimeout ?? defaultClientWebSocketConnectTimeout({driver})
+    this._initialRootVisitTimeout = initialRootVisitTimeout
     this._httpHost = httpHost
     this._httpPort = httpPort
     this._httpConnectHost = httpConnectHost
@@ -885,7 +889,7 @@ export default class SystemTest extends Browser {
    * @returns {Promise<void>}
    */
   async visitInitialRootPath(rootPath) {
-    const deadline = Date.now() + this.getTimeouts()
+    const deadline = Date.now() + this._initialRootVisitTimeout
 
     while (true) {
       try {


### PR DESCRIPTION
Summary
- Route native waitForTestIDText through the scroll-aware native lookup loop.
- Keep scrollIntoView scoped to the owner test id instead of text selectors.
- Extend the Appium driver regression spec to cover text that becomes reachable only after viewport scanning.
- Give the initial root path visit its own retry timeout so Android Chrome can recover from slow emulator host routing without loosening normal command timeouts.
- Fall back to reading the owner element text when native id+text selectors miss a Text node carrying the requested test id.

Validation
- npm test -- spec/appium-driver.spec.js
- npm test -- spec/system-test-root-path.spec.js
- npm run lint
- npm run build