### PR TITLE
Fix overlapping Appium startup lifecycle

### DIFF
--- a/changelog.d/20260724120000-appium-start-singleflight.md
+++ b/changelog.d/20260724120000-appium-start-singleflight.md
@@ -1,0 +1,1 @@
+Make system-test startup single-flight and safely order stop/reinitialize against pending Appium session creation.

--- a/spec/system-test-start.spec.js
+++ b/spec/system-test-start.spec.js
@@ -162,6 +162,30 @@ describe("SystemTest.start", () => {
     expect(systemTest.isStarted()).toBeTrue()
   })
 
+  it("shares one startup queued behind a pending stop", async () => {
+    const driverStop = createDeferred()
+    const {driverAdapter, systemTest} = createSystemTest(jasmine.createSpy("start").and.resolveTo(undefined))
+
+    driverAdapter.stop.and.returnValue(driverStop.promise)
+    await systemTest.start()
+
+    const stopPromise = systemTest.stop()
+    const firstQueuedStart = systemTest.start()
+    const secondQueuedStart = systemTest.start()
+
+    try {
+      expect(secondQueuedStart).toBe(firstQueuedStart)
+      expect(driverAdapter.start).toHaveBeenCalledTimes(1)
+    } finally {
+      driverStop.resolve()
+    }
+
+    await Promise.all([stopPromise, firstQueuedStart, secondQueuedStart])
+
+    expect(driverAdapter.start).toHaveBeenCalledTimes(2)
+    expect(systemTest.isStarted()).toBeTrue()
+  })
+
   it("reinitializes only after pending startup is stopped", async () => {
     const firstDriverStart = createDeferred()
     const replacementDriverStart = createDeferred()

--- a/spec/system-test-start.spec.js
+++ b/spec/system-test-start.spec.js
@@ -170,10 +170,18 @@ describe("SystemTest.start", () => {
 
   it("shares one startup queued behind a pending stop", async () => {
     const driverStop = createDeferred()
-    const {driverAdapter, systemTest} = createSystemTest(jasmine.createSpy("start").and.resolveTo(undefined))
+    const events = []
+    const {driverAdapter, systemTest} = createSystemTest(jasmine.createSpy("start").and.callFake(async () => {
+      events.push(`driver-start-${driverAdapter.start.calls.count()}`)
+    }))
 
+    systemTest.startScoundrel.and.callFake(function() {
+      events.push("scoundrel-start")
+      this.scoundrelWss = /** @type {any} */ ({})
+    })
     driverAdapter.stop.and.returnValue(driverStop.promise)
     await systemTest.start()
+    events.length = 0
 
     const stopPromise = systemTest.stop()
     const firstQueuedStart = systemTest.start()
@@ -190,6 +198,7 @@ describe("SystemTest.start", () => {
 
     expect(driverAdapter.start).toHaveBeenCalledTimes(2)
     expect(systemTest.startScoundrel).toHaveBeenCalledTimes(2)
+    expect(events).toEqual(["scoundrel-start", "driver-start-2"])
     expect(systemTest.isStarted()).toBeTrue()
   })
 

--- a/spec/system-test-start.spec.js
+++ b/spec/system-test-start.spec.js
@@ -48,8 +48,14 @@ function createSystemTest(start) {
 
 describe("SystemTest.start", () => {
   beforeEach(() => {
-    spyOn(SystemTest.prototype, "startScoundrel").and.callFake(() => {})
-    spyOn(SystemTest.prototype, "stopScoundrel").and.resolveTo(undefined)
+    spyOn(SystemTest.prototype, "startScoundrel").and.callFake(function() {
+      this.scoundrelWss = /** @type {any} */ ({})
+    })
+    spyOn(SystemTest.prototype, "stopScoundrel").and.callFake(async function() {
+      this.scoundrelWss = undefined
+      this.serverWebSocket = undefined
+      this.server = undefined
+    })
   })
 
   it("shares one pending driver startup between overlapping callers", async () => {
@@ -183,6 +189,7 @@ describe("SystemTest.start", () => {
     await Promise.all([stopPromise, firstQueuedStart, secondQueuedStart])
 
     expect(driverAdapter.start).toHaveBeenCalledTimes(2)
+    expect(systemTest.startScoundrel).toHaveBeenCalledTimes(2)
     expect(systemTest.isStarted()).toBeTrue()
   })
 

--- a/spec/system-test-start.spec.js
+++ b/spec/system-test-start.spec.js
@@ -1,0 +1,206 @@
+// @ts-check
+
+import SystemTest from "../src/system-test.js"
+
+/** @returns {{promise: Promise<void>, reject: (error: Error) => void, resolve: () => void}} */
+function createDeferred() {
+  /** @type {() => void} */
+  let resolve = () => {}
+  /** @type {(error: Error) => void} */
+  let reject = () => {}
+  const promise = new Promise((promiseResolve, promiseReject) => {
+    resolve = promiseResolve
+    reject = promiseReject
+  })
+
+  return {promise, reject, resolve}
+}
+
+/**
+ * @param {jasmine.Spy} start
+ * @returns {{driverAdapter: Record<string, jasmine.Spy>, systemTest: SystemTest}}
+ */
+function createSystemTest(start) {
+  const systemTest = new SystemTest({
+    driver: {
+      type: "appium",
+      options: {
+        capabilities: {
+          browserName: ""
+        }
+      }
+    }
+  })
+  const driverAdapter = {
+    setBaseUrl: jasmine.createSpy("setBaseUrl"),
+    setTimeouts: jasmine.createSpy("setTimeouts").and.resolveTo(undefined),
+    start,
+    stop: jasmine.createSpy("stop").and.resolveTo(undefined)
+  }
+
+  systemTest.driverAdapter = /** @type {any} */ (driverAdapter)
+  spyOn(systemTest, "startWebSocketServer").and.resolveTo(undefined)
+  spyOn(systemTest, "findByTestID").and.resolveTo(/** @type {any} */ ({}))
+  spyOn(systemTest, "waitForClientWebSocket").and.resolveTo(undefined)
+
+  return {driverAdapter, systemTest}
+}
+
+describe("SystemTest.start", () => {
+  beforeEach(() => {
+    spyOn(SystemTest.prototype, "startScoundrel").and.callFake(() => {})
+    spyOn(SystemTest.prototype, "stopScoundrel").and.resolveTo(undefined)
+  })
+
+  it("shares one pending driver startup between overlapping callers", async () => {
+    const driverStart = createDeferred()
+    const {driverAdapter, systemTest} = createSystemTest(jasmine.createSpy("start").and.returnValue(driverStart.promise))
+
+    const firstStart = systemTest.start()
+    await Promise.resolve()
+    const secondStart = systemTest.start()
+
+    try {
+      expect(secondStart).toBe(firstStart)
+      expect(driverAdapter.start).toHaveBeenCalledTimes(1)
+      expect(systemTest.isStarted()).toBeFalse()
+    } finally {
+      driverStart.resolve()
+    }
+
+    await Promise.all([firstStart, secondStart])
+
+    expect(driverAdapter.start).toHaveBeenCalledTimes(1)
+    expect(systemTest.isStarted()).toBeTrue()
+  })
+
+  it("clears failed startup state so a later call can retry", async () => {
+    const failedDriverStart = createDeferred()
+    const {driverAdapter, systemTest} = createSystemTest(jasmine.createSpy("start").and.returnValues(failedDriverStart.promise, Promise.resolve()))
+    const firstStart = systemTest.start()
+    const secondStart = systemTest.start()
+    const startupResults = Promise.allSettled([firstStart, secondStart])
+    const startupError = new Error("driver startup failed")
+
+    failedDriverStart.reject(startupError)
+
+    const [firstResult, secondResult] = await startupResults
+
+    expect(firstResult).toEqual({status: "rejected", reason: startupError})
+    expect(secondResult).toEqual({status: "rejected", reason: startupError})
+    expect(driverAdapter.start).toHaveBeenCalledTimes(1)
+    expect(systemTest.isStarted()).toBeFalse()
+
+    await systemTest.start()
+
+    expect(driverAdapter.start).toHaveBeenCalledTimes(2)
+    expect(systemTest.isStarted()).toBeTrue()
+  })
+
+  it("waits for pending startup before stopping its resources", async () => {
+    const driverStart = createDeferred()
+    const {driverAdapter, systemTest} = createSystemTest(jasmine.createSpy("start").and.returnValue(driverStart.promise))
+    const startPromise = systemTest.start()
+    const stopPromise = systemTest.stop()
+
+    await Promise.resolve()
+    expect(driverAdapter.stop).not.toHaveBeenCalled()
+
+    driverStart.resolve()
+    await Promise.all([startPromise, stopPromise])
+
+    expect(driverAdapter.stop).toHaveBeenCalledTimes(1)
+    expect(systemTest.isStarted()).toBeFalse()
+  })
+
+  it("still stops resources after pending startup fails", async () => {
+    const driverStart = createDeferred()
+    const {driverAdapter, systemTest} = createSystemTest(jasmine.createSpy("start").and.returnValue(driverStart.promise))
+    const startPromise = systemTest.start()
+    const startupResult = Promise.allSettled([startPromise])
+    const stopPromise = systemTest.stop()
+
+    driverStart.reject(new Error("driver startup failed"))
+    await stopPromise
+
+    expect((await startupResult)[0].status).toEqual("rejected")
+    expect(driverAdapter.stop).toHaveBeenCalledTimes(1)
+    expect(systemTest.isStarted()).toBeFalse()
+  })
+
+  it("starts again only after a pending stop disposes the first startup", async () => {
+    const firstDriverStart = createDeferred()
+    const secondDriverStart = createDeferred()
+    const secondDriverStartEntered = createDeferred()
+    const events = []
+    const {driverAdapter, systemTest} = createSystemTest(jasmine.createSpy("start").and.callFake(() => {
+      events.push(`start-${driverAdapter.start.calls.count()}`)
+      if (driverAdapter.start.calls.count() === 2) secondDriverStartEntered.resolve()
+      return driverAdapter.start.calls.count() === 1 ? firstDriverStart.promise : secondDriverStart.promise
+    }))
+
+    driverAdapter.stop.and.callFake(async () => {
+      events.push("stop")
+    })
+
+    const firstStart = systemTest.start()
+    const stopPromise = systemTest.stop()
+    const replacementStart = systemTest.start()
+
+    await Promise.resolve()
+    expect(driverAdapter.start).toHaveBeenCalledTimes(1)
+    firstDriverStart.resolve()
+    await stopPromise
+    await secondDriverStartEntered.promise
+
+    expect(events).toEqual(["start-1", "stop", "start-2"])
+    expect(driverAdapter.start).toHaveBeenCalledTimes(2)
+
+    secondDriverStart.resolve()
+    await Promise.all([firstStart, replacementStart])
+
+    expect(systemTest.isStarted()).toBeTrue()
+  })
+
+  it("reinitializes only after pending startup is stopped", async () => {
+    const firstDriverStart = createDeferred()
+    const replacementDriverStart = createDeferred()
+    const replacementDriverStartEntered = createDeferred()
+    const events = []
+    const {driverAdapter, systemTest} = createSystemTest(jasmine.createSpy("start").and.callFake(async () => {
+      events.push("old-start")
+      await firstDriverStart.promise
+    }))
+    const replacementDriverAdapter = {
+      setBaseUrl: jasmine.createSpy("replacementSetBaseUrl"),
+      setTimeouts: jasmine.createSpy("replacementSetTimeouts").and.resolveTo(undefined),
+      start: jasmine.createSpy("replacementStart").and.callFake(async () => {
+        events.push("replacement-start")
+        replacementDriverStartEntered.resolve()
+        await replacementDriverStart.promise
+      }),
+      stop: jasmine.createSpy("replacementStop").and.resolveTo(undefined)
+    }
+
+    driverAdapter.stop.and.callFake(async () => {
+      events.push("old-stop")
+    })
+    spyOn(systemTest, "createDriver").and.returnValue(/** @type {any} */ (replacementDriverAdapter))
+
+    const firstStart = systemTest.start()
+    const reinitializePromise = systemTest.reinitialize()
+
+    expect(replacementDriverAdapter.start).not.toHaveBeenCalled()
+    firstDriverStart.resolve()
+    await firstStart
+    await replacementDriverStartEntered.promise
+
+    expect(events).toEqual(["old-start", "old-stop", "replacement-start"])
+    replacementDriverStart.resolve()
+    await reinitializePromise
+
+    expect(driverAdapter.stop).toHaveBeenCalledTimes(1)
+    expect(replacementDriverAdapter.start).toHaveBeenCalledTimes(1)
+    expect(systemTest.isStarted()).toBeTrue()
+  })
+})

--- a/spec/system-test-start.spec.js
+++ b/spec/system-test-start.spec.js
@@ -174,6 +174,7 @@ describe("SystemTest.start", () => {
 
     driverAdapter.stop.and.returnValue(driverStop.promise)
     await systemTest.start()
+    systemTest._ignoredScoundrelClientCount = 1
 
     const stopPromise = systemTest.stop()
     const firstQueuedStart = systemTest.start()
@@ -190,6 +191,7 @@ describe("SystemTest.start", () => {
 
     expect(driverAdapter.start).toHaveBeenCalledTimes(2)
     expect(systemTest.startScoundrel).toHaveBeenCalledTimes(2)
+    expect(systemTest._ignoredScoundrelClientCount).toEqual(0)
     expect(systemTest.isStarted()).toBeTrue()
   })
 

--- a/src/system-test.js
+++ b/src/system-test.js
@@ -830,7 +830,10 @@ export default class SystemTest extends Browser {
    */
   async startInternal() {
     this.debugLog("Start called")
-    if (!this.scoundrelWss) this.startScoundrel()
+    if (!this.scoundrelWss) {
+      this._ignoredScoundrelClientCount = 0
+      this.startScoundrel()
+    }
     // Native Appium app sessions launch an installed app instead of a web page, so they follow the
     // native lifecycle (no dist HTTP server, no driver navigation, WebSocket started before the app)
     // even when SYSTEM_TEST_HOST is "dist".

--- a/src/system-test.js
+++ b/src/system-test.js
@@ -111,6 +111,12 @@ export default class SystemTest extends Browser {
   communicator = undefined
 
   _started = false
+  /** @type {Promise<void> | undefined} */
+  _startPromise = undefined
+  /** @type {Promise<void> | undefined} */
+  _stopPromise = undefined
+  /** @type {Promise<void> | undefined} */
+  _reinitializePromise = undefined
   _clientWsPort = 1985
   _clientWsConnectTimeout = CLIENT_WEBSOCKET_CONNECT_TIMEOUT_MS
   _initialRootVisitTimeout = DEFAULT_INITIAL_ROOT_VISIT_TIMEOUT_MS
@@ -777,7 +783,32 @@ export default class SystemTest extends Browser {
    * Starts the system test
    * @returns {Promise<void>}
    */
-  async start() {
+  start() {
+    if (this._reinitializePromise) return this._reinitializePromise
+    if (this._stopPromise) return this._stopPromise.then(() => this.start())
+    if (this._started) return Promise.resolve()
+    if (this._startPromise) return this._startPromise
+
+    const startPromise = this.startInternal()
+
+    this._startPromise = startPromise
+    void startPromise.then(
+      () => {
+        if (this._startPromise === startPromise) this._startPromise = undefined
+      },
+      () => {
+        if (this._startPromise === startPromise) this._startPromise = undefined
+      }
+    )
+
+    return startPromise
+  }
+
+  /**
+   * Performs an unguarded system test startup.
+   * @returns {Promise<void>}
+   */
+  async startInternal() {
     this.debugLog("Start called")
     // Native Appium app sessions launch an installed app instead of a web page, so they follow the
     // native lifecycle (no dist HTTP server, no driver navigation, WebSocket started before the app)
@@ -1185,7 +1216,44 @@ export default class SystemTest extends Browser {
    * Stops the system test
    * @returns {Promise<void>}
    */
-  async stop() {
+  stop() {
+    if (this._reinitializePromise) return this._reinitializePromise.then(() => this.stop())
+    if (this._stopPromise) return this._stopPromise
+
+    const startPromise = this._startPromise
+    const stopPromise = (async () => {
+      this._started = false
+
+      if (startPromise) {
+        try {
+          await startPromise
+        } catch {
+          // Startup failure does not remove resources that were already created.
+        }
+      }
+
+      await this.stopInternal()
+      this._started = false
+    })()
+
+    this._stopPromise = stopPromise
+    void stopPromise.then(
+      () => {
+        if (this._stopPromise === stopPromise) this._stopPromise = undefined
+      },
+      () => {
+        if (this._stopPromise === stopPromise) this._stopPromise = undefined
+      }
+    )
+
+    return stopPromise
+  }
+
+  /**
+   * Performs an unguarded system test teardown.
+   * @returns {Promise<void>}
+   */
+  async stopInternal() {
     await this.stopScoundrel()
     if (this.ws) {
       this.ws.close()
@@ -1205,29 +1273,59 @@ export default class SystemTest extends Browser {
    * Fully tears down and restarts the system test instance.
    * @returns {Promise<void>}
    */
-  async reinitialize() {
-    await this.stop()
+  reinitialize() {
+    if (this._reinitializePromise) return this._reinitializePromise
 
-    this._started = false
-    this._baseSelector = undefined
-    this.currentUrl = undefined
-    this.driver = undefined
-    this.driverAdapter = this.createDriver(this._driverConfig)
-    this.ws = null
-    this.clientWss = undefined
-    this.scoundrelWss = undefined
-    this.server = undefined
-    this.serverWebSocket = undefined
-    this._ignoredScoundrelClientCount = 0
-    this.systemTestHttpServer = undefined
-    this._httpServerError = undefined
-    this.waitForClientWebSocketPromiseReject = undefined
-    this.waitForClientWebSocketPromiseResolve = undefined
-    this.communicator = new SystemTestCommunicator({onCommand: this.onCommandReceived})
-    this.setCommunicator(this.communicator)
+    const startPromise = this._startPromise
+    const stopPromise = this._stopPromise
+    const reinitializePromise = (async () => {
+      if (stopPromise) {
+        await stopPromise
+      } else {
+        if (startPromise) {
+          try {
+            await startPromise
+          } catch {
+            // Startup failure does not remove resources that were already created.
+          }
+        }
 
-    this.startScoundrel()
-    await this.start()
+        await this.stopInternal()
+      }
+
+      this._started = false
+      this._baseSelector = undefined
+      this.currentUrl = undefined
+      this.driver = undefined
+      this.driverAdapter = this.createDriver(this._driverConfig)
+      this.ws = null
+      this.clientWss = undefined
+      this.scoundrelWss = undefined
+      this.server = undefined
+      this.serverWebSocket = undefined
+      this._ignoredScoundrelClientCount = 0
+      this.systemTestHttpServer = undefined
+      this._httpServerError = undefined
+      this.waitForClientWebSocketPromiseReject = undefined
+      this.waitForClientWebSocketPromiseResolve = undefined
+      this.communicator = new SystemTestCommunicator({onCommand: this.onCommandReceived})
+      this.setCommunicator(this.communicator)
+
+      this.startScoundrel()
+      await this.startInternal()
+    })()
+
+    this._reinitializePromise = reinitializePromise
+    void reinitializePromise.then(
+      () => {
+        if (this._reinitializePromise === reinitializePromise) this._reinitializePromise = undefined
+      },
+      () => {
+        if (this._reinitializePromise === reinitializePromise) this._reinitializePromise = undefined
+      }
+    )
+
+    return reinitializePromise
   }
 
   /**

--- a/src/system-test.js
+++ b/src/system-test.js
@@ -114,6 +114,8 @@ export default class SystemTest extends Browser {
   /** @type {Promise<void> | undefined} */
   _startPromise = undefined
   /** @type {Promise<void> | undefined} */
+  _queuedStartPromise = undefined
+  /** @type {Promise<void> | undefined} */
   _stopPromise = undefined
   /** @type {Promise<void> | undefined} */
   _reinitializePromise = undefined
@@ -785,7 +787,22 @@ export default class SystemTest extends Browser {
    */
   start() {
     if (this._reinitializePromise) return this._reinitializePromise
-    if (this._stopPromise) return this._stopPromise.then(() => this.start())
+    if (this._queuedStartPromise) return this._queuedStartPromise
+    if (this._stopPromise) {
+      const queuedStartPromise = this._stopPromise.then(
+        () => {
+          if (this._queuedStartPromise === queuedStartPromise) this._queuedStartPromise = undefined
+          return this.start()
+        },
+        (error) => {
+          if (this._queuedStartPromise === queuedStartPromise) this._queuedStartPromise = undefined
+          throw error
+        }
+      )
+
+      this._queuedStartPromise = queuedStartPromise
+      return queuedStartPromise
+    }
     if (this._started) return Promise.resolve()
     if (this._startPromise) return this._startPromise
 

--- a/src/system-test.js
+++ b/src/system-test.js
@@ -470,6 +470,9 @@ export default class SystemTest extends Browser {
       await timeout({timeout: this.getTimeouts(), errorMessage: "timeout while waiting for Scoundrel to stop"}, async () => await /** @type {NonNullable<typeof this.server>} */ (this.server).close())
     }
     await this.closeWebSocketServer(this.scoundrelWss, "Scoundrel WebSocket server")
+    this.scoundrelWss = undefined
+    this.serverWebSocket = undefined
+    this.server = undefined
   }
 
   /**
@@ -827,6 +830,7 @@ export default class SystemTest extends Browser {
    */
   async startInternal() {
     this.debugLog("Start called")
+    if (!this.scoundrelWss) this.startScoundrel()
     // Native Appium app sessions launch an installed app instead of a web page, so they follow the
     // native lifecycle (no dist HTTP server, no driver navigation, WebSocket started before the app)
     // even when SYSTEM_TEST_HOST is "dist".


### PR DESCRIPTION
## Summary

- make `SystemTest.start()` a strict single-flight operation, including starts queued behind an in-progress stop
- wait for non-cancellable Appium/WebDriver startup before teardown/reinitialization so a late session cannot kill its replacement
- dispose stale late-started sessions and restore consistent lifecycle state after startup failures
- add deterministic concurrency regressions for joined starts, queued starts, stop/reinitialize during startup, late resolution, and retry after failure

## Root cause

A timed-out Appium `builder.build()` could continue for several minutes. A replacement test session could start meanwhile; when the old request finally completed, UiAutomator2 force-stopped the active instrumentation process. This produced `instrumentation process is not running` / UiAutomator2 proxy failures in downstream Android CI.

## Validation

- `npx jasmine spec/system-test-start.spec.js` — 7 specs, 0 failures
- `npx jasmine spec/system-test-run.spec.js spec/appium-driver.spec.js` — 42 specs, 0 failures
- `npm run typecheck` — passed
- `npm run eslint` — passed with zero warnings
- `git diff --check 803c52a2402638116eae680e9052c19ba9062337...7cf7aee86241b462f483cd86d502fa40c9ce6d2e` — passed
- independent exact-diff re-review — PASS, no findings

## Validation gap

The full repository suite was not used as an acceptance gate because its Selenium server exits with status 127 in the available environment. The directly affected lifecycle, run, Appium, typecheck, lint, and diff-integrity gates are green.

## Release status

No npm release has been published and no downstream dependency has been updated.
