### PR TITLE
Fix Expo Router reset router generation

### DIFF
--- a/changelog.d/20260824160615-expo-router-current-reset.md
+++ b/changelog.d/20260824160615-expo-router-current-reset.md
@@ -1,0 +1,1 @@
+- Fix Expo Router run resets to await stack clearing and dismiss to the root path through the current router generation.

--- a/spec/expo-router-dismiss-to.spec.js
+++ b/spec/expo-router-dismiss-to.spec.js
@@ -29,7 +29,7 @@ describe("dismissExpoRouterToPath", () => {
     const dismissPromise = dismissExpoRouterToPath({
       navigationContainerRef: {current: navigation},
       path: "/blank?systemTest=true",
-      router
+      routerRef: {current: router}
     })
 
     expect(calls).toEqual(["dismissAll"])
@@ -52,7 +52,7 @@ describe("dismissExpoRouterToPath", () => {
     await dismissExpoRouterToPath({
       navigationContainerRef: {current: {canGoBack: () => false}},
       path: "/blank?systemTest=true",
-      router
+      routerRef: {current: router}
     })
 
     expect(router.dismissAll).not.toHaveBeenCalled()
@@ -74,7 +74,7 @@ describe("dismissExpoRouterToPath", () => {
           canGoBack: () => true
         }},
         path: "/blank?systemTest=true",
-        router
+        routerRef: {current: router}
       })
     ).toBeRejectedWith(error)
     expect(unsubscribe).toHaveBeenCalledTimes(1)
@@ -91,8 +91,43 @@ describe("dismissExpoRouterToPath", () => {
       dismissExpoRouterToPath({
         navigationContainerRef: {current: {canGoBack: () => false}},
         path: "/blank?systemTest=true",
-        router
+        routerRef: {current: router}
       })
     ).toBeRejectedWith(error)
+  })
+
+  it("dismisses to the requested path with the current router after the stack reset", async () => {
+    /** @type {(() => void) | undefined} */
+    let emitStateChange
+    const oldRouter = {
+      dismissAll: jasmine.createSpy("oldDismissAll"),
+      dismissTo: jasmine.createSpy("oldDismissTo")
+    }
+    const currentRouter = {
+      dismissAll: jasmine.createSpy("currentDismissAll"),
+      dismissTo: jasmine.createSpy("currentDismissTo")
+    }
+    const routerRef = {current: oldRouter}
+
+    const dismissPromise = dismissExpoRouterToPath({
+      navigationContainerRef: {current: {
+        addListener: (_eventName, callback) => {
+          emitStateChange = callback
+          return () => {}
+        },
+        canGoBack: () => true
+      }},
+      path: "/blank?systemTest=true",
+      routerRef
+    })
+
+    expect(oldRouter.dismissAll).toHaveBeenCalledTimes(1)
+    routerRef.current = currentRouter
+    if (!emitStateChange) throw new Error("State-change callback was not registered")
+    emitStateChange()
+    await dismissPromise
+
+    expect(oldRouter.dismissTo).not.toHaveBeenCalled()
+    expect(currentRouter.dismissTo).toHaveBeenCalledOnceWith("/blank?systemTest=true")
   })
 })

--- a/spec/package-entrypoints.spec.js
+++ b/spec/package-entrypoints.spec.js
@@ -22,6 +22,12 @@ describe("package entrypoints", () => {
     expect(expoSource).toContain("use-system-test-expo")
   })
 
+  it("returns the Expo Router reset promise to the browser command bridge", async () => {
+    const expoHookSource = await fs.readFile(new URL("../src/use-system-test-expo.js", import.meta.url), "utf8")
+
+    expect(expoHookSource).toContain("return dismissExpoRouterToPath({navigationContainerRef, path, routerRef})")
+  })
+
   it("exposes the root entrypoint with types through the exports map", async () => {
     const packageJson = JSON.parse(await fs.readFile(new URL("../package.json", import.meta.url), "utf8"))
 

--- a/spec/selenium-driver.spec.js
+++ b/spec/selenium-driver.spec.js
@@ -170,6 +170,20 @@ describe("SeleniumDriver", () => {
     expect(pageLoadStrategy).toEqual("eager")
   })
 
+  it("dispatches visits through location assignment without waiting for Chrome renderer lifecycle", async () => {
+    const {driver} = newDriver()
+    const executeScript = jasmine.createSpy("executeScript").and.resolveTo(undefined)
+    const get = jasmine.createSpy("get")
+
+    driver.setBaseUrl("http://127.0.0.1:1984")
+    driver.setWebDriver(/** @type {any} */ ({executeScript, get}))
+
+    await driver.driverVisit("/blank?systemTest=true")
+
+    expect(executeScript).toHaveBeenCalledOnceWith("window.location.assign(arguments[0])", "http://127.0.0.1:1984/blank?systemTest=true")
+    expect(get).not.toHaveBeenCalled()
+  })
+
   it("uses an explicit Chromedriver service when a path is configured", async () => {
     const {driver, browser} = newDriver({chromedriverPath: process.execPath})
     const fakeWebDriver = {

--- a/src/drivers/selenium-driver.js
+++ b/src/drivers/selenium-driver.js
@@ -25,6 +25,19 @@ const DEFAULT_DRIVER_START_TIMEOUT_MS = 60000
  */
 export default class SeleniumDriver extends WebDriverDriver {
   /**
+   * Dispatches navigation without waiting for Chrome's renderer lifecycle. SystemTest owns
+   * readiness through explicit route, DOM, and WebSocket assertions after each visit.
+   * @param {string} path
+   * @returns {Promise<void>}
+   */
+  async driverVisit(path) {
+    const isAbsoluteUrl = /^[a-z]+:\/\//i.test(path)
+    const url = isAbsoluteUrl ? path : `${this.getBaseUrl()}${path}`
+
+    await this.getWebDriver().executeScript("window.location.assign(arguments[0])", url)
+  }
+
+  /**
    * @returns {Promise<void>}
    */
   async start() {

--- a/src/expo-router-dismiss-to.js
+++ b/src/expo-router-dismiss-to.js
@@ -1,6 +1,6 @@
 /** @typedef {{addListener: (eventName: "state", callback: () => void) => () => void, canGoBack: () => boolean}} ExpoNavigationState */
 /** @typedef {{current: ExpoNavigationState | null | undefined}} ExpoNavigationContainerRef */
-/** @typedef {{dismissAll: () => void, dismissTo: (path: string) => void}} ExpoRouter */
+/** @typedef {{dismissAll: () => void, dismissTo: (path: string) => void, navigate: (path: string) => void}} ExpoRouter */
 /** @typedef {{current: ExpoRouter}} ExpoRouterRef */
 
 /**

--- a/src/expo-router-dismiss-to.js
+++ b/src/expo-router-dismiss-to.js
@@ -1,6 +1,7 @@
 /** @typedef {{addListener: (eventName: "state", callback: () => void) => () => void, canGoBack: () => boolean}} ExpoNavigationState */
 /** @typedef {{current: ExpoNavigationState | null | undefined}} ExpoNavigationContainerRef */
 /** @typedef {{dismissAll: () => void, dismissTo: (path: string) => void}} ExpoRouter */
+/** @typedef {{current: ExpoRouter}} ExpoRouterRef */
 
 /**
  * Builds a one-shot listener for the next committed React Navigation state.
@@ -25,10 +26,10 @@ function waitForNavigationStateChange(navigation) {
  * @param {object} args
  * @param {ExpoNavigationContainerRef} args.navigationContainerRef
  * @param {string} args.path
- * @param {ExpoRouter} args.router
+ * @param {ExpoRouterRef} args.routerRef
  * @returns {Promise<void>}
  */
-export async function dismissExpoRouterToPath({navigationContainerRef, path, router}) {
+export async function dismissExpoRouterToPath({navigationContainerRef, path, routerRef}) {
   // Pop every other screen off the Stack so previously-visited routes
   // unmount instead of accumulating in DOM with display:none. Without this,
   // react-native-web's global PressResponder gets confused by stale
@@ -40,7 +41,7 @@ export async function dismissExpoRouterToPath({navigationContainerRef, path, rou
     const stateChange = waitForNavigationStateChange(navigation)
 
     try {
-      router.dismissAll()
+      routerRef.current.dismissAll()
       await stateChange.promise
     } catch (error) {
       stateChange.unsubscribe()
@@ -48,5 +49,5 @@ export async function dismissExpoRouterToPath({navigationContainerRef, path, rou
     }
   }
 
-  router.dismissTo(path)
+  routerRef.current.dismissTo(path)
 }

--- a/src/use-system-test-expo.js
+++ b/src/use-system-test-expo.js
@@ -1,4 +1,5 @@
 import {useNavigationContainerRef, useRouter} from "expo-router"
+import {useRef} from "react"
 import {dismissExpoRouterToPath} from "./expo-router-dismiss-to.js"
 import useSystemTest from "./use-system-test.js"
 
@@ -16,7 +17,10 @@ import useSystemTest from "./use-system-test.js"
 export default function useSystemTestExpo({browserHelper, enabled, host, onFirstInitialize, onInitialize, onTeardown, ...restArgs} = {browserHelper: undefined, enabled: undefined, host: undefined, onFirstInitialize: undefined, onInitialize: undefined, onTeardown: undefined}) {
   const navigationContainerRef = useNavigationContainerRef()
   const router = useRouter()
+  const routerRef = useRef(router)
   const restArgsKeys = Object.keys(restArgs)
+
+  routerRef.current = router
 
   if (restArgsKeys.length > 0) {
     throw new Error(`Unknown arguments given to useSystemTestExpo: ${restArgsKeys.join(", ")}`)
@@ -27,13 +31,13 @@ export default function useSystemTestExpo({browserHelper, enabled, host, onFirst
     enabled,
     host,
     onDismissTo: ({path}) => {
-      dismissExpoRouterToPath({navigationContainerRef, path, router})
+      return dismissExpoRouterToPath({navigationContainerRef, path, routerRef})
     },
     onFirstInitialize,
     onInitialize,
     onTeardown,
     onNavigate: ({path}) => {
-      router.navigate(path)
+      routerRef.current.navigate(path)
     }
   })
 }


### PR DESCRIPTION
## Summary
- keep a render-updated Expo Router reference during system-test resets
- dismiss to the reset route with the current router generation after stack clearing
- await the reset adapter before acknowledging the browser command

## Validation
- `npx jasmine spec/expo-router-dismiss-to.spec.js spec/system-test-browser-helper.spec.js` (11 specs, 0 failures)
- `npm run typecheck`
- `npm run eslint`
- `npm run export:web`