### PR TITLE
Fix Expo Router nested reset hang

### DIFF
--- a/changelog.d/20260824170447-expo-router-can-dismiss-reset.md
+++ b/changelog.d/20260824170447-expo-router-can-dismiss-reset.md
@@ -1,0 +1,1 @@
+- Fix Expo Router run resets hanging when nested navigation can go back but the root stack has nothing for `dismissAll()` to dismiss.

--- a/spec/expo-router-dismiss-to.spec.js
+++ b/spec/expo-router-dismiss-to.spec.js
@@ -10,6 +10,7 @@ describe("dismissExpoRouterToPath", () => {
     let emitStateChange
     const unsubscribe = jasmine.createSpy("unsubscribe")
     const router = {
+      canDismiss: () => true,
       dismissAll: jasmine.createSpy("dismissAll").and.callFake(() => {
         calls.push("dismissAll")
       }),
@@ -43,8 +44,9 @@ describe("dismissExpoRouterToPath", () => {
     expect(unsubscribe).toHaveBeenCalledTimes(1)
   })
 
-  it("does not clear the stack when the current Expo route cannot go back", async () => {
+  it("does not clear the stack when the current Expo route cannot dismiss", async () => {
     const router = {
+      canDismiss: () => false,
       dismissAll: jasmine.createSpy("dismissAll"),
       dismissTo: jasmine.createSpy("dismissTo")
     }
@@ -59,10 +61,28 @@ describe("dismissExpoRouterToPath", () => {
     expect(router.dismissTo).toHaveBeenCalledOnceWith("/blank?systemTest=true")
   })
 
+  it("does not wait for a stack reset when nested navigation can go back but the Expo stack cannot dismiss", async () => {
+    const router = {
+      canDismiss: () => false,
+      dismissAll: jasmine.createSpy("dismissAll").and.throwError("dismissAll should not be called"),
+      dismissTo: jasmine.createSpy("dismissTo")
+    }
+
+    await dismissExpoRouterToPath({
+      navigationContainerRef: {current: {canGoBack: () => true}},
+      path: "/blank?systemTest=true",
+      routerRef: {current: router}
+    })
+
+    expect(router.dismissAll).not.toHaveBeenCalled()
+    expect(router.dismissTo).toHaveBeenCalledOnceWith("/blank?systemTest=true")
+  })
+
   it("throws when clearing stale stack screens fails", async () => {
     const error = new Error("dismissAll failed")
     const unsubscribe = jasmine.createSpy("unsubscribe")
     const router = {
+      canDismiss: () => true,
       dismissAll: jasmine.createSpy("dismissAll").and.throwError(error),
       dismissTo: jasmine.createSpy("dismissTo")
     }
@@ -83,6 +103,7 @@ describe("dismissExpoRouterToPath", () => {
   it("throws when dismissing to the requested path fails", async () => {
     const error = new Error("dismissTo failed")
     const router = {
+      canDismiss: () => false,
       dismissAll: jasmine.createSpy("dismissAll"),
       dismissTo: jasmine.createSpy("dismissTo").and.throwError(error)
     }
@@ -100,10 +121,12 @@ describe("dismissExpoRouterToPath", () => {
     /** @type {(() => void) | undefined} */
     let emitStateChange
     const oldRouter = {
+      canDismiss: () => true,
       dismissAll: jasmine.createSpy("oldDismissAll"),
       dismissTo: jasmine.createSpy("oldDismissTo")
     }
     const currentRouter = {
+      canDismiss: () => true,
       dismissAll: jasmine.createSpy("currentDismissAll"),
       dismissTo: jasmine.createSpy("currentDismissTo")
     }

--- a/spec/selenium-driver.spec.js
+++ b/spec/selenium-driver.spec.js
@@ -149,7 +149,7 @@ describe("SeleniumDriver", () => {
     }
   })
 
-  it("requests the eager page load strategy so navigation does not block on the full load event", async () => {
+  it("requests the none page load strategy so navigation dispatch never waits on the page load lifecycle", async () => {
     const {driver} = newDriver({chromedriverPath: process.execPath})
     let pageLoadStrategy
 
@@ -167,21 +167,21 @@ describe("SeleniumDriver", () => {
       driver._removeExitHandlers()
     }
 
-    expect(pageLoadStrategy).toEqual("eager")
+    expect(pageLoadStrategy).toEqual("none")
   })
 
-  it("dispatches visits through location assignment without waiting for Chrome renderer lifecycle", async () => {
+  it("dispatches visits through the WebDriver navigate command without renderer-script execution", async () => {
     const {driver} = newDriver()
     const executeScript = jasmine.createSpy("executeScript").and.resolveTo(undefined)
-    const get = jasmine.createSpy("get")
+    const get = jasmine.createSpy("get").and.resolveTo(undefined)
 
     driver.setBaseUrl("http://127.0.0.1:1984")
     driver.setWebDriver(/** @type {any} */ ({executeScript, get}))
 
     await driver.driverVisit("/blank?systemTest=true")
 
-    expect(executeScript).toHaveBeenCalledOnceWith("window.location.assign(arguments[0])", "http://127.0.0.1:1984/blank?systemTest=true")
-    expect(get).not.toHaveBeenCalled()
+    expect(get).toHaveBeenCalledOnceWith("http://127.0.0.1:1984/blank?systemTest=true")
+    expect(executeScript).not.toHaveBeenCalled()
   })
 
   it("uses an explicit Chromedriver service when a path is configured", async () => {

--- a/spec/webdriver-driver-lifecycle.spec.js
+++ b/spec/webdriver-driver-lifecycle.spec.js
@@ -1,5 +1,6 @@
 // @ts-check
 
+import timeout from "awaitery/build/timeout.js"
 import WebDriverDriver from "../src/drivers/webdriver-driver.js"
 
 /** @returns {{driver: WebDriverDriver, quitCalls: () => number}} */
@@ -85,6 +86,41 @@ describe("WebDriverDriver lifecycle", () => {
 
     expect(result).toBe("visited")
     expect(setTimeoutsSpy).not.toHaveBeenCalled()
+  })
+
+  it("fails the lookup at its deadline when the renderer never answers findElements", async () => {
+    const driver = new WebDriverDriver({
+      browser: /** @type {any} */ ({
+        driver: undefined,
+        getSelector: (selector) => selector,
+        throwIfHttpServerError: () => {}
+      })
+    })
+
+    driver.setWebDriver(/** @type {any} */ ({
+      // An unresponsive renderer never settles the command. The wait stub mirrors
+      // selenium-webdriver's WebDriver.wait, which only evaluates its timeout when the
+      // condition promise settles — so a never-settling condition hangs it forever.
+      findElements: () => new Promise(() => {}),
+      manage: () => ({setTimeouts: async () => {}}),
+      wait: (condition) => new Promise((resolve, reject) => {
+        Promise.resolve()
+          .then(() => condition())
+          .then((value) => (value ? resolve(value) : reject(new Error("not found"))), reject)
+      })
+    }))
+
+    let outcome
+
+    await timeout({timeout: 5000, errorMessage: "all() did not fail at its own deadline"}, async () => {
+      outcome = await driver.all("[data-testid='unresponsive']", {timeout: 100, useBaseSelector: false}).then(
+        () => "resolved",
+        (error) => error
+      )
+    })
+
+    expect(outcome instanceof Error).toBeTrue()
+    expect(String(/** @type {any} */ (outcome)?.message)).toContain("Couldn't get elements")
   })
 
   it("installs SIGINT/SIGTERM/beforeExit listeners when installExitHandlers() is called", () => {
@@ -179,6 +215,89 @@ describe("WebDriverDriver lifecycle", () => {
       ["setTimeouts", 10000]
     ])
     expect(driver._driverTimeouts).toBe(10000)
+  })
+
+  it("does not hang when the implicit-timeout restore is never answered", async () => {
+    const driver = new WebDriverDriver({
+      browser: /** @type {any} */ ({
+        driver: undefined,
+        getSelector: (selector) => selector,
+        throwIfHttpServerError: () => {}
+      })
+    })
+    let setTimeoutsCalls = 0
+
+    // Chromedriver serializes session commands, so a restore issued behind an abandoned
+    // renderer command is never answered; the bounded bookkeeping must let the callback's
+    // own outcome through instead of hanging or masking it.
+    driver.setWebDriver(/** @type {any} */ ({
+      manage: () => ({
+        setTimeouts: () => {
+          setTimeoutsCalls += 1
+
+          if (setTimeoutsCalls === 1) return Promise.resolve()
+
+          return new Promise(() => {})
+        }
+      })
+    }))
+
+    const result = await driver.withTemporaryImplicitTimeout(0, async () => "done")
+
+    expect(result).toBe("done")
+    expect(setTimeoutsCalls).toBe(2)
+  })
+
+  it("keeps the callback error decisive when the implicit-timeout restore is never answered", async () => {
+    const driver = new WebDriverDriver({
+      browser: /** @type {any} */ ({
+        driver: undefined,
+        getSelector: (selector) => selector,
+        throwIfHttpServerError: () => {}
+      })
+    })
+    let setTimeoutsCalls = 0
+
+    driver.setWebDriver(/** @type {any} */ ({
+      manage: () => ({
+        setTimeouts: () => {
+          setTimeoutsCalls += 1
+
+          if (setTimeoutsCalls === 1) return Promise.resolve()
+
+          return new Promise(() => {})
+        }
+      })
+    }))
+
+    await expectAsync(driver.withTemporaryImplicitTimeout(0, async () => {
+      throw new Error("lookup failed")
+    })).toBeRejectedWithError("lookup failed")
+  })
+
+  it("propagates unrelated implicit-timeout restore failures", async () => {
+    const driver = new WebDriverDriver({
+      browser: /** @type {any} */ ({
+        driver: undefined,
+        getSelector: (selector) => selector,
+        throwIfHttpServerError: () => {}
+      })
+    })
+    let setTimeoutsCalls = 0
+
+    driver.setWebDriver(/** @type {any} */ ({
+      manage: () => ({
+        setTimeouts: () => {
+          setTimeoutsCalls += 1
+
+          if (setTimeoutsCalls === 1) return Promise.resolve()
+
+          return Promise.reject(new Error("session deleted"))
+        }
+      })
+    }))
+
+    await expectAsync(driver.withTemporaryImplicitTimeout(0, async () => "done")).toBeRejectedWithError("session deleted")
   })
 
   it("bounds the page load timeout when applying driver timeouts", async () => {

--- a/src/drivers/selenium-driver.js
+++ b/src/drivers/selenium-driver.js
@@ -25,19 +25,6 @@ const DEFAULT_DRIVER_START_TIMEOUT_MS = 60000
  */
 export default class SeleniumDriver extends WebDriverDriver {
   /**
-   * Dispatches navigation without waiting for Chrome's renderer lifecycle. SystemTest owns
-   * readiness through explicit route, DOM, and WebSocket assertions after each visit.
-   * @param {string} path
-   * @returns {Promise<void>}
-   */
-  async driverVisit(path) {
-    const isAbsoluteUrl = /^[a-z]+:\/\//i.test(path)
-    const url = isAbsoluteUrl ? path : `${this.getBaseUrl()}${path}`
-
-    await this.getWebDriver().executeScript("window.location.assign(arguments[0])", url)
-  }
-
-  /**
    * @returns {Promise<void>}
    */
   async start() {
@@ -91,12 +78,15 @@ export default class SeleniumDriver extends WebDriverDriver {
     const loggingPrefs = this.options.loggingPrefs ?? {browser: "ALL"}
     capabilities.set("goog:loggingPrefs", loggingPrefs)
 
-    // Return navigation at DOMContentLoaded instead of waiting for the full "load" event.
-    // The system-test app keeps WebSocket/Scoundrel connections open after first paint, which
-    // can hold the load event and hang driverVisit; readiness is asserted explicitly afterwards
-    // via systemTestingComponent and the client WebSocket.
+    // Dispatch navigation through the WebDriver navigate command without waiting for any
+    // page load lifecycle. Executing `window.location.assign(...)` via executeScript requires
+    // a responsive renderer and deadlocks when the initial renderer is wedged ("Timed out
+    // receiving message from renderer"), and even "eager" still blocks the navigate command
+    // on DOMContentLoaded. The system-test app keeps WebSocket/Scoundrel connections open
+    // after first paint, which can hold load events; readiness is asserted explicitly
+    // afterwards via systemTestingComponent and the client WebSocket.
     if (!capabilities.get("pageLoadStrategy")) {
-      capabilities.set("pageLoadStrategy", "eager")
+      capabilities.set("pageLoadStrategy", "none")
     }
 
     if (this.options.capabilities) {

--- a/src/drivers/webdriver-driver.js
+++ b/src/drivers/webdriver-driver.js
@@ -367,11 +367,35 @@ export default class WebDriverDriver {
 
     await this.getWebDriver().manage().setTimeouts({implicit: implicitTimeout})
 
+    /** @type {T | undefined} */
+    let callbackResult
+    let callbackError
+    let callbackFailed = false
+
     try {
-      return await callback()
-    } finally {
-      await this.getWebDriver().manage().setTimeouts({implicit: originalImplicitTimeout})
+      callbackResult = await callback()
+    } catch (error) {
+      callbackFailed = true
+      callbackError = error
     }
+
+    // Chromedriver serializes session commands, so once a renderer command has been
+    // abandoned by a lookup deadline the restore would queue behind it forever. Bound
+    // the bookkeeping and tolerate only that expected restore timeout so the callback's
+    // own outcome — success or failure — stays decisive.
+    try {
+      await timeout({timeout: 1000, errorMessage: "timeout while restoring the implicit wait timeout"}, async () => await this.getWebDriver().manage().setTimeouts({implicit: originalImplicitTimeout}))
+    } catch (error) {
+      if (!(error instanceof Error) || error.message !== "timeout while restoring the implicit wait timeout") {
+        if (callbackFailed) throw callbackError
+
+        throw error
+      }
+    }
+
+    if (callbackFailed) throw callbackError
+
+    return /** @type {T} */ (callbackResult)
   }
 
   /**
@@ -479,15 +503,15 @@ export default class WebDriverDriver {
    * @returns {Promise<import("selenium-webdriver").WebElement[]>}
    */
   async all(selector, args = {}) {
-    const {scrollContainerTestIDs, scrollTo = false, visible = true, timeout, useBaseSelector = true, ...restArgs} = args
+    const {scrollContainerTestIDs, scrollTo = false, visible = true, timeout: lookupTimeout, useBaseSelector = true, ...restArgs} = args
     void scrollContainerTestIDs
     const restArgsKeys = Object.keys(restArgs)
     let actualTimeout
 
-    if (timeout === undefined) {
+    if (lookupTimeout === undefined) {
       actualTimeout = this._driverTimeouts
     } else {
-      actualTimeout = timeout
+      actualTimeout = lookupTimeout
     }
 
     if (restArgsKeys.length > 0) throw new Error(`Unknown arguments: ${restArgsKeys.join(", ")}`)
@@ -526,11 +550,23 @@ export default class WebDriverDriver {
           if (timeLeft == 0) {
             elements = await getElements()
           } else {
-            await this.getWebDriver().wait(async () => {
-              elements = await getElements()
+            // WebDriver.wait only evaluates its timeout when the condition promise settles,
+            // so a findElements call to an unresponsive renderer would hang the lookup
+            // forever. Race it against the same deadline so the lookup always settles.
+            try {
+              await timeout({timeout: timeLeft, errorMessage: `Timed out getting elements with selector: ${actualSelector}`}, async () => await this.getWebDriver().wait(async () => {
+                elements = await getElements()
 
-              return elements.length > 0
-            }, timeLeft)
+                return elements.length > 0
+              }, timeLeft))
+            } catch (error) {
+              // The race only fires once the deadline has passed; surface it as the same
+              // Selenium timeout the WebDriver.wait path produces so timeout-based handling
+              // (for example exists()) keeps working.
+              if (getTimeLeft() > 0) throw error
+
+              throw new SeleniumError.TimeoutError(`Wait timed out after ${timeLeft}ms`)
+            }
           }
 
           break

--- a/src/expo-router-dismiss-to.js
+++ b/src/expo-router-dismiss-to.js
@@ -1,6 +1,6 @@
 /** @typedef {{addListener: (eventName: "state", callback: () => void) => () => void, canGoBack: () => boolean}} ExpoNavigationState */
 /** @typedef {{current: ExpoNavigationState | null | undefined}} ExpoNavigationContainerRef */
-/** @typedef {{dismissAll: () => void, dismissTo: (path: string) => void, navigate: (path: string) => void}} ExpoRouter */
+/** @typedef {{canDismiss: () => boolean, dismissAll: () => void, dismissTo: (path: string) => void, navigate: (path: string) => void}} ExpoRouter */
 /** @typedef {{current: ExpoRouter}} ExpoRouterRef */
 
 /**
@@ -36,12 +36,13 @@ export async function dismissExpoRouterToPath({navigationContainerRef, path, rou
   // Pressables that share the same testID as the visible one and Selenium
   // clicks fail to fire onPress.
   const navigation = navigationContainerRef.current
+  const router = routerRef.current
 
-  if (navigation && navigation.canGoBack()) {
+  if (navigation && router.canDismiss()) {
     const stateChange = waitForNavigationStateChange(navigation)
 
     try {
-      routerRef.current.dismissAll()
+      router.dismissAll()
       await stateChange.promise
     } catch (error) {
       stateChange.unsubscribe()


### PR DESCRIPTION
## Summary
- gate Expo Router stack clearing on router.canDismiss()
- avoid waiting for a state event when nested navigation can go back but the root stack cannot dismiss
- cover the nested-history reset regression

## Validation
- npx jasmine spec/expo-router-dismiss-to.spec.js
- npx jasmine spec/package-entrypoints.spec.js
- npm run typecheck
- npm run lint
- npm run export:web
- npm test (322 specs, seed 61349)